### PR TITLE
Scope likes controller to current user and return refreshed like collections

### DIFF
--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -1,26 +1,35 @@
 class Api::V1::LikesController < ApplicationController
+  before_action :authenticate_user
   before_action :set_review
 
   def create
-    like = Like.new(like_params)
+    like = current_user.likes.new(review: @review)
+
     if like.save
-      render status: :created
+      render_likes(status: :created)
+    else
+      render json: { errors: like.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   def destroy
-    @like = current_user.likes.find_by(review_id: @review.id)
-    @like.destroy
-    render json: @like
+    like = current_user.likes.find_by!(review_id: @review.id)
+    like.destroy
+
+    render_likes
   end
 
   private
+
   def like_params
-    params.require(:like).permit(:review_id, :user_id)
+    params.permit(:review_id, :user_id)
   end
 
   def set_review
-    @review = Review.find(params[:review_id])
+    @review = Review.find(like_params[:review_id] || params[:review_id])
   end
 
+  def render_likes(status: :ok)
+    render json: { likes: @review.likes.reload }, status: status
+  end
 end

--- a/back/spec/requests/api/v1/likes_request_spec.rb
+++ b/back/spec/requests/api/v1/likes_request_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Likes", type: :request do
+  let(:user) { create(:user) }
+  let(:review) { create(:review) }
+  let(:headers) { { 'Authorization' => "Bearer #{generate_jwt_token(user)}" } }
 
+  describe "POST /api/v1/spots/:spot_id/reviews/:review_id/likes" do
+    let(:other_user) { create(:user) }
+
+    it "creates a like for the current user and returns the updated likes array" do
+      expect do
+        post "/api/v1/spots/#{review.spot_id}/reviews/#{review.id}/likes",
+             params: { review_id: review.id, user_id: other_user.id },
+             headers: headers
+      end.to change(Like, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+
+      json = JSON.parse(response.body)
+      expect(json['likes']).to be_an(Array)
+      expect(json['likes']).to include(include('user_id' => user.id, 'review_id' => review.id))
+      expect(json['likes']).not_to include(include('user_id' => other_user.id))
+    end
+  end
+
+  describe "DELETE /api/v1/spots/:spot_id/reviews/:review_id/likes/:id" do
+    let!(:like) { create(:like, user: user, review: review) }
+
+    it "destroys the like and returns the refreshed likes array" do
+      expect do
+        delete "/api/v1/spots/#{review.spot_id}/reviews/#{review.id}/likes/#{like.id}",
+               headers: headers
+      end.to change(Like, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['likes']).to eq([])
+    end
+  end
+
+  private
+
+  def generate_jwt_token(user)
+    UserAuth::AuthToken.new(payload: { sub: user.id }).token
+  end
 end


### PR DESCRIPTION
## Summary
- update the likes controller to permit flat parameters, scope creates to the current user, and respond with the refreshed likes collection
- add request specs that post the flat payload and verify the returned likes array after create and destroy

## Testing
- bundle exec rspec spec/requests/api/v1/likes_request_spec.rb *(fails: bundler could not find the `rspec` executable because Ruby 3.3.0 specified in Gemfile is unavailable in the container)*
- bundle exec rake spec SPEC=spec/requests/api/v1/likes_request_spec.rb *(fails: Gemfile requires Ruby 3.3.0 but the container provides Ruby 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_b_68cfe50620888333ab4d1e2b26e3bedd