### PR TITLE
Update spot show payload with detailed serialization

### DIFF
--- a/back/app/serializers/application_serializer.rb
+++ b/back/app/serializers/application_serializer.rb
@@ -9,4 +9,24 @@ class ApplicationSerializer
   private
 
   attr_reader :object, :options
-end 
+
+  def serialize_uploader(uploader)
+    return { url: nil } if uploader.nil?
+
+    url = uploader.respond_to?(:url) ? uploader.url : nil
+
+    { url: url }
+  end
+
+  def serialize_active_hash(resource)
+    return nil if resource.blank?
+
+    {
+      id: resource.id,
+      type: resource.class.name.demodulize.underscore,
+      attributes: {
+        name: resource.name
+      }
+    }
+  end
+end

--- a/back/app/serializers/like_serializer.rb
+++ b/back/app/serializers/like_serializer.rb
@@ -1,0 +1,10 @@
+class LikeSerializer < ApplicationSerializer
+  def as_json(options = {})
+    {
+      id: object.id,
+      user_id: object.user_id,
+      created_at: object.created_at,
+      updated_at: object.updated_at
+    }
+  end
+end

--- a/back/app/serializers/review_serializer.rb
+++ b/back/app/serializers/review_serializer.rb
@@ -3,8 +3,10 @@ class ReviewSerializer < ApplicationSerializer
     {
       id: object.id,
       title: object.title,
-      content: object.content,
+      text: object.text,
       rating: object.rating,
+      wentday: object.wentday,
+      image: serialize_uploader(object.image),
       created_at: object.created_at,
       updated_at: object.updated_at
     }
@@ -12,7 +14,8 @@ class ReviewSerializer < ApplicationSerializer
 
   def with_user
     as_json.merge(
-      user: UserSerializer.new(object.user).as_json
+      user: UserSerializer.new(object.user).as_json,
+      likes: object.likes.map { |like| LikeSerializer.new(like).as_json }
     )
   end
 

--- a/back/app/serializers/user_serializer.rb
+++ b/back/app/serializers/user_serializer.rb
@@ -4,7 +4,7 @@ class UserSerializer < ApplicationSerializer
       id: object.id,
       name: object.name,
       email: object.email,
-      image: object.image.url,
+      image: serialize_uploader(object.image),
       introduction: object.introduction,
       created_at: object.created_at
     }


### PR DESCRIPTION
## Summary
- update the show action to return a `spot` payload with nested details plus the top-level metadata the front end consumes
- enhance the spot- and review-related serializers (and add a like serializer) to expose structured JSON for images, reviews, likes, and related ActiveHash data
- extend the request spec for `GET /api/v1/spots/:id` to cover the new response schema

## Testing
- `bundle exec rake spec SPEC=spec/requests/api/v1/spots_request_spec.rb` *(fails: Ruby 3.2.3 used in container but Gemfile requires 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_b_68cfe4ff14c0833395c4300f852bd7c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Spot detail now returns richer data: reviews (title, text, rating, wentday, images), likes per review, average rating, total reviews count, prefecture and location info, and a flag indicating if you’ve favorited the spot. Photos and user images are delivered as structured objects.
- Performance
  - Faster spot loading via optimized data fetching.
- Bug Fixes
  - Field naming aligned (content -> text) and counts/averages made consistent.
- Tests
  - Expanded request tests to validate the new response structure and aggregated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->