### PR TITLE
Fix frontend user data keys and follow actions

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,27 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "Nature-Spots"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []

--- a/front/components/user/likeReview.vue
+++ b/front/components/user/likeReview.vue
@@ -113,7 +113,7 @@ const formatDate = (dateString: string) => {
 onMounted(async () => {
   try {
     const res = await $api.get("/api/v1/users/user_data");
-    reviews.value = res.data.like_reviews || [];
+    reviews.value = res.data.liked_reviews || [];
   } catch (error) {
     console.error("ユーザーデータの取得に失敗しました:", error);
   }

--- a/front/components/user/mypage.vue
+++ b/front/components/user/mypage.vue
@@ -113,7 +113,7 @@ const formatDate = (dateString: string) => {
 onMounted(async () => {
   try {
     const res = await $api.get("/api/v1/users/user_data");
-    reviews.value = res.data.review || [];
+    reviews.value = res.data.reviews || [];
   } catch (error) {
     console.error("ユーザーデータの取得に失敗しました:", error);
   }

--- a/front/components/userPage/userData.vue
+++ b/front/components/userPage/userData.vue
@@ -71,8 +71,8 @@ onMounted(async () => {
           : res.data.reviews;
     }
 
-    follow.value = res.data.follow || [];
-    follower.value = res.data.follower || [];
+    follow.value = res.data.followings || [];
+    follower.value = res.data.followers || [];
   } catch (error) {
     console.error("ユーザーデータの取得に失敗しました:", error);
   }

--- a/front/pages/account/settings.vue
+++ b/front/pages/account/settings.vue
@@ -126,30 +126,33 @@
       </v-tab-item>
       <v-tab-item>
         <v-card flat>
-          <v-card-text v-for="v in followUser" :key="v.id">
-            <v-avatar size="100">
-              <v-img :src="v.image.url" />
-            </v-avatar>
-            <nuxt-link :to="`/user/${v.id}`" class="text-decoration-none">
-              <v-card-title>{{ v.name }}</v-card-title>
-            </nuxt-link>
-            <follow-btn />
-          </v-card-text>
-        </v-card>
-      </v-tab-item>
-      <v-tab-item>
-        <v-card flat>
-          <v-card-text v-for="t in follower" :key="t.id">
-            <v-avatar size="100">
-              <v-img :src="t.image.url" />
-            </v-avatar>
-            <nuxt-link :to="`/user/${t.id}`" class="text-decoration-none">
-              <v-card-title>{{ t.name }}</v-card-title>
-            </nuxt-link>
-            <follow-btn />
-          </v-card-text>
-        </v-card>
-      </v-tab-item>
+        <v-card-text v-for="v in followUser" :key="v.id">
+          <v-avatar size="100">
+            <v-img :src="v.image.url" />
+          </v-avatar>
+          <nuxt-link :to="`/user/${v.id}`" class="text-decoration-none">
+            <v-card-title>{{ v.name }}</v-card-title>
+          </nuxt-link>
+          <follow-btn :user-id="v.id" :initial-is-following="true" />
+        </v-card-text>
+      </v-card>
+    </v-tab-item>
+    <v-tab-item>
+      <v-card flat>
+        <v-card-text v-for="t in follower" :key="t.id">
+          <v-avatar size="100">
+            <v-img :src="t.image.url" />
+          </v-avatar>
+          <nuxt-link :to="`/user/${t.id}`" class="text-decoration-none">
+            <v-card-title>{{ t.name }}</v-card-title>
+          </nuxt-link>
+          <follow-btn
+            :user-id="t.id"
+            :initial-is-following="isFollowingUser(t.id)"
+          />
+        </v-card-text>
+      </v-card>
+    </v-tab-item>
     </v-tabs>
   </v-card>
 </template>
@@ -159,12 +162,12 @@ export default {
   data() {
     return {
       tab: null,
-      reviews: {},
-      myReview: {},
-      likeSpot: {},
-      followUser: {},
-      follower: {},
-      user: {},
+      reviews: [],
+      myReview: [],
+      likeSpot: [],
+      followUser: [],
+      follower: [],
+      user: null,
       photo: null,
     };
   },
@@ -174,15 +177,20 @@ export default {
       .then((res) => {
         this.user = res.data.user;
         this.photo = res.data.user.image.url;
-        this.reviews = JSON.parse(res.data.like_reviews);
-        this.myReview = JSON.parse(res.data.review);
-        this.likeSpot = res.data.favorite;
-        this.followUser = res.data.follow;
-        this.follower = res.data.follower;
+        this.reviews = res.data.liked_reviews || [];
+        this.myReview = res.data.reviews || [];
+        this.likeSpot = res.data.favorites || [];
+        this.followUser = res.data.followings || [];
+        this.follower = res.data.followers || [];
       })
       .catch((error) => {
         console.error(error);
       });
+  },
+  methods: {
+    isFollowingUser(userId) {
+      return this.followUser.some((user) => user.id === userId);
+    },
   },
 };
 </script>

--- a/front/pages/account/settings.vue
+++ b/front/pages/account/settings.vue
@@ -126,33 +126,33 @@
       </v-tab-item>
       <v-tab-item>
         <v-card flat>
-        <v-card-text v-for="v in followUser" :key="v.id">
-          <v-avatar size="100">
-            <v-img :src="v.image.url" />
-          </v-avatar>
-          <nuxt-link :to="`/user/${v.id}`" class="text-decoration-none">
-            <v-card-title>{{ v.name }}</v-card-title>
-          </nuxt-link>
-          <follow-btn :user-id="v.id" :initial-is-following="true" />
-        </v-card-text>
-      </v-card>
-    </v-tab-item>
-    <v-tab-item>
-      <v-card flat>
-        <v-card-text v-for="t in follower" :key="t.id">
-          <v-avatar size="100">
-            <v-img :src="t.image.url" />
-          </v-avatar>
-          <nuxt-link :to="`/user/${t.id}`" class="text-decoration-none">
-            <v-card-title>{{ t.name }}</v-card-title>
-          </nuxt-link>
-          <follow-btn
-            :user-id="t.id"
-            :initial-is-following="isFollowingUser(t.id)"
-          />
-        </v-card-text>
-      </v-card>
-    </v-tab-item>
+          <v-card-text v-for="v in followUser" :key="v.id">
+            <v-avatar size="100">
+              <v-img :src="v.image.url" />
+            </v-avatar>
+            <nuxt-link :to="`/user/${v.id}`" class="text-decoration-none">
+              <v-card-title>{{ v.name }}</v-card-title>
+            </nuxt-link>
+            <follow-btn :user-id="v.id" :initial-is-following="true" />
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+      <v-tab-item>
+        <v-card flat>
+          <v-card-text v-for="t in follower" :key="t.id">
+            <v-avatar size="100">
+              <v-img :src="t.image.url" />
+            </v-avatar>
+            <nuxt-link :to="`/user/${t.id}`" class="text-decoration-none">
+              <v-card-title>{{ t.name }}</v-card-title>
+            </nuxt-link>
+            <follow-btn
+              :user-id="t.id"
+              :initial-is-following="isFollowingUser(t.id)"
+            />
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
     </v-tabs>
   </v-card>
 </template>

--- a/front/pages/favorites.vue
+++ b/front/pages/favorites.vue
@@ -19,13 +19,13 @@ export default {
   },
   data() {
     return {
-      fspots: {},
+      fspots: [],
     };
   },
   mounted() {
     this.$axios.get("/api/v1/users/user_data").then((res) => {
       if (res.data) {
-        this.fspots = res.data.favorite;
+        this.fspots = res.data.favorites || [];
       }
     });
   },


### PR DESCRIPTION
## 概要\n- ユーザーデータの参照キーをバックエンド仕様（favorites/liked_reviews/followings/followers/reviews）に統一\n- フォロー/アンフォローの対象ID解決とDELETEエンドポイントを修正\n\n## 変更内容\n- 設定/お気に入り/マイページ/いいね/ユーザーページの参照キー修正\n- follow-btnにuserId・initialIsFollowingを追加し、ボタン初期状態と対象IDを明示\n- 設定画面のフォロー/フォロワー一覧でIDと初期状態を渡すように修正\n\n## テスト\n- yarn --cwd front test:unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * APIレスポンスのフィールド名（単数→複数）とデータ形状（オブジェクト→配列）に対応し、データ取得の整合性を改善

* **New Features**
  * フォロー／アンフォローにユーザー向けトースト通知と同期ロジックを追加

* **Chores**
  * 公開設定項目をプロジェクト設定ファイルに追加（プロジェクト名、モード、ツール関連の設定）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->