### PR TITLE
ci: add Blacksmith A/B benchmark workflows

### DIFF
--- a/.github/workflows/backend-ci-blacksmith.yml
+++ b/.github/workflows/backend-ci-blacksmith.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'back/**'
       - '.github/workflows/backend-ci.yml'
+      - '.github/workflows/backend-ci-blacksmith.yml'
 
 jobs:
   test:

--- a/.github/workflows/backend-ci-blacksmith.yml
+++ b/.github/workflows/backend-ci-blacksmith.yml
@@ -1,0 +1,92 @@
+name: Backend CI (Blacksmith)
+
+on:
+  pull_request:
+    paths:
+      - 'back/**'
+      - '.github/workflows/backend-ci.yml'
+
+jobs:
+  test:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: nature_spots_test
+          MYSQL_USER: test_user
+          MYSQL_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    defaults:
+      run:
+        working-directory: ./back
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.3'
+          bundler-cache: true
+          working-directory: ./back
+
+      - name: Create database.yml for CI
+        run: |
+          cat << EOF > config/database.yml
+          test:
+            adapter: mysql2
+            encoding: utf8mb4
+            collation: utf8mb4_unicode_ci
+            pool: 5
+            username: test_user
+            password: test_password
+            host: 127.0.0.1
+            port: 3306
+            database: nature_spots_test
+          EOF
+
+      - name: Setup test database
+        env:
+          RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: 3306
+          DATABASE_USER: test_user
+          DATABASE_PASSWORD: test_password
+          DATABASE_NAME: nature_spots_test
+        run: |
+          bundle exec rails db:create
+          mysql -h 127.0.0.1 -u root -proot -e "ALTER DATABASE nature_spots_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+          bundle exec rails db:migrate
+
+      - name: Run RSpec tests
+        env:
+          RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: 3306
+          DATABASE_USER: test_user
+          DATABASE_PASSWORD: test_password
+          DATABASE_NAME: nature_spots_test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: bundle exec rspec
+
+      - name: Run security audit
+        run: |
+          bundle exec brakeman --no-pager
+          bundle exec bundle-audit check --update
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: back/coverage/

--- a/.github/workflows/backend-ci-blacksmith.yml
+++ b/.github/workflows/backend-ci-blacksmith.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.BLACKSMITH_RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
 
     services:
       mysql:

--- a/.github/workflows/frontend-ci-blacksmith.yml
+++ b/.github/workflows/frontend-ci-blacksmith.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.BLACKSMITH_RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
 
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run tests
         run: yarn test
-        if: ${{ false }} # テストが設定されたら有効化
+        if: ${{ vars.RUN_FRONTEND_TESTS == 'true' }}
 
       - name: Check bundle size
         run: |

--- a/.github/workflows/frontend-ci-blacksmith.yml
+++ b/.github/workflows/frontend-ci-blacksmith.yml
@@ -1,0 +1,59 @@
+name: Frontend CI (Blacksmith)
+
+on:
+  pull_request:
+    paths:
+      - 'front/**'
+      - '.github/workflows/frontend-ci.yml'
+
+jobs:
+  test:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    defaults:
+      run:
+        working-directory: ./front
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: front/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run linting
+        run: yarn lint:ox
+
+      - name: Run type checking
+        run: yarn type-check
+
+      - name: Run format check
+        run: yarn format:check
+
+      - name: Build application
+        run: yarn build
+        env:
+          NITRO_PRESET: node-server
+
+      - name: Run tests
+        run: yarn test
+        if: ${{ false }} # テストが設定されたら有効化
+
+      - name: Check bundle size
+        run: |
+          echo "Bundle size analysis:"
+          du -sh .output/public/_nuxt/
+          find .output/public/_nuxt/ -name "*.js" -size +500k -exec ls -lh {} \;
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nuxt-build
+          path: front/.output/

--- a/.github/workflows/frontend-ci-blacksmith.yml
+++ b/.github/workflows/frontend-ci-blacksmith.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'front/**'
       - '.github/workflows/frontend-ci.yml'
+      - '.github/workflows/frontend-ci-blacksmith.yml'
 
 jobs:
   test:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run tests
         run: yarn test
-        if: ${{ false }} # テストが設定されたら有効化
+        if: ${{ vars.RUN_FRONTEND_TESTS == 'true' }}
 
       - name: Check bundle size
         run: |

--- a/docs/ci/blacksmith-benchmark.md
+++ b/docs/ci/blacksmith-benchmark.md
@@ -13,8 +13,10 @@ Compare CI runtime between GitHub-hosted runners and Blacksmith runners using su
 - Exclusions: any non-successful runs (`failure`, `cancelled`, `timed_out`, etc.)
 
 ## Runner Configuration
-- Blacksmith runner tag: `blacksmith-4vcpu-ubuntu-2204`
-- Note: use one fixed tag from the Blacksmith dashboard for the entire benchmark window.
+- `BLACKSMITH_RUNNER_LABEL` repository variable controls the runner label.
+- Default label in workflows: `blacksmith-4vcpu-ubuntu-2404`
+- Note: set a fixed label from the Blacksmith dashboard for the entire benchmark window.
+- Optional: set `RUN_FRONTEND_TESTS=true` when including `yarn test` in both frontend workflows.
 
 ## Baseline Snapshot (2026-02-14)
 - Backend CI successful runs (last 50): avg `61s`

--- a/docs/ci/blacksmith-benchmark.md
+++ b/docs/ci/blacksmith-benchmark.md
@@ -1,0 +1,61 @@
+# Blacksmith Benchmark Log
+
+## Purpose
+Compare CI runtime between GitHub-hosted runners and Blacksmith runners using successful runs on the same `headSha`.
+
+## Scope
+- Repository: `Ryo-cool/Nature-Spots` (organization-side benchmark repository)
+- Workflows:
+  - `Backend CI` vs `Backend CI (Blacksmith)`
+  - `Frontend CI` vs `Frontend CI (Blacksmith)`
+- Event: `pull_request`
+- Pairing rule: only successful run pairs with the same `headSha`
+- Exclusions: any non-successful runs (`failure`, `cancelled`, `timed_out`, etc.)
+
+## Runner Configuration
+- Blacksmith runner tag: `blacksmith-4vcpu-ubuntu-2204`
+- Note: use one fixed tag from the Blacksmith dashboard for the entire benchmark window.
+
+## Baseline Snapshot (2026-02-14)
+- Backend CI successful runs (last 50): avg `61s`
+- Frontend CI successful runs (last 50): avg `73s`
+
+## Execution Procedure
+1. Run base and Blacksmith workflows in parallel on the same PR.
+2. Collect at least 5 successful pairs per workflow.
+3. Run the command below to generate the comparison report.
+
+```bash
+./scripts/ci/compare_blacksmith.sh <owner/repo>
+```
+
+Example:
+
+```bash
+./scripts/ci/compare_blacksmith.sh my-org/Nature-Spots
+```
+
+## Result Template
+### Measurement Window
+- Start:
+- End:
+- Runner tag:
+- Pair count (backend):
+- Pair count (frontend):
+
+### Backend Summary
+- base avg / median / p90:
+- blacksmith avg / median / p90:
+- delta avg / median / p90:
+- Notes:
+
+### Frontend Summary
+- base avg / median / p90:
+- blacksmith avg / median / p90:
+- delta avg / median / p90:
+- Notes:
+
+### Conclusion
+- Observed speed difference:
+- Adoption decision:
+- Follow-up actions:

--- a/scripts/ci/compare_blacksmith.sh
+++ b/scripts/ci/compare_blacksmith.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-${GITHUB_REPOSITORY:-Ryo-cool/Nature-Spots}}"
+LIMIT="${LIMIT:-200}"
+
+BACKEND_BASE_WORKFLOW="${BACKEND_BASE_WORKFLOW:-Backend CI}"
+BACKEND_BLACKSMITH_WORKFLOW="${BACKEND_BLACKSMITH_WORKFLOW:-Backend CI (Blacksmith)}"
+FRONTEND_BASE_WORKFLOW="${FRONTEND_BASE_WORKFLOW:-Frontend CI}"
+FRONTEND_BLACKSMITH_WORKFLOW="${FRONTEND_BLACKSMITH_WORKFLOW:-Frontend CI (Blacksmith)}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+fetch_runs() {
+  local workflow_name="$1"
+  local output_file="$2"
+  local raw_file
+  local err_file
+
+  raw_file="$(mktemp)"
+  err_file="$(mktemp)"
+
+  if ! gh run list \
+    --repo "$REPO" \
+    --workflow "$workflow_name" \
+    --limit "$LIMIT" \
+    --json headSha,startedAt,updatedAt,status,conclusion,event,url >"$raw_file" 2>"$err_file"; then
+    if grep -q "could not find any workflows named" "$err_file"; then
+      echo "Warning: workflow not found: $workflow_name" >&2
+      echo '[]' > "$output_file"
+      rm -f "$raw_file" "$err_file"
+      return 0
+    fi
+
+    cat "$err_file" >&2
+    rm -f "$raw_file" "$err_file"
+    return 1
+  fi
+
+  jq '
+      map(
+        select(
+          .status == "completed"
+          and .conclusion == "success"
+          and .event == "pull_request"
+          and .startedAt != null
+          and .updatedAt != null
+          and .headSha != null
+        )
+      )
+      | map(
+          . + {
+            durationSec: ((.updatedAt | fromdateiso8601) - (.startedAt | fromdateiso8601))
+          }
+        )
+    ' "$raw_file" > "$output_file"
+
+  rm -f "$raw_file" "$err_file"
+}
+
+build_pairs() {
+  local label="$1"
+  local base_file="$2"
+  local blacksmith_file="$3"
+  local output_file="$4"
+
+  jq -n \
+    --arg label "$label" \
+    --slurpfile base "$base_file" \
+    --slurpfile blacksmith "$blacksmith_file" '
+      def latest_by_sha(items):
+        reduce items[] as $row (
+          {};
+          .[$row.headSha] = (
+            if .[$row.headSha] == null or .[$row.headSha].updatedAt < $row.updatedAt
+            then $row
+            else .[$row.headSha]
+            end
+          )
+        );
+
+      (latest_by_sha($base[0])) as $base_map |
+      (latest_by_sha($blacksmith[0])) as $blacksmith_map |
+      [
+        ($base_map | keys[]) as $sha
+        | select($blacksmith_map[$sha] != null)
+        | {
+            label: $label,
+            date: ($blacksmith_map[$sha].updatedAt[0:10]),
+            sha: $sha,
+            base_sec: $base_map[$sha].durationSec,
+            blacksmith_sec: $blacksmith_map[$sha].durationSec,
+            delta_sec: ($blacksmith_map[$sha].durationSec - $base_map[$sha].durationSec),
+            delta_pct: (
+              if $base_map[$sha].durationSec == 0
+              then null
+              else ((($blacksmith_map[$sha].durationSec - $base_map[$sha].durationSec) / $base_map[$sha].durationSec) * 100)
+              end
+            ),
+            base_url: $base_map[$sha].url,
+            blacksmith_url: $blacksmith_map[$sha].url
+          }
+      ]
+      | sort_by(.date, .sha)
+    ' > "$output_file"
+}
+
+print_report() {
+  local title="$1"
+  local pairs_file="$2"
+
+  echo ""
+  echo "== $title =="
+
+  jq -r '
+    if length == 0 then
+      "No matched successful pairs found."
+    else
+      (["date","sha","base_sec","blacksmith_sec","delta_sec","delta_pct"] | @tsv),
+      (.[] | [
+        .date,
+        (.sha[0:12]),
+        (.base_sec | tostring),
+        (.blacksmith_sec | tostring),
+        (.delta_sec | tostring),
+        (if .delta_pct == null then "n/a" else ((.delta_pct | round | tostring) + "%") end)
+      ] | @tsv)
+    end
+  ' "$pairs_file" | column -t -s $'\t'
+
+  jq -r '
+    def stats(values):
+      if (values | length) == 0 then
+        null
+      else
+        (values | sort) as $sorted
+        | (values | length) as $count
+        | {
+            count: $count,
+            avg: ((values | add) / $count),
+            median: (
+              if ($count % 2) == 1 then
+                $sorted[($count / 2 | floor)]
+              else
+                (($sorted[($count / 2) - 1] + $sorted[($count / 2)]) / 2)
+              end
+            ),
+            p90: $sorted[(((($count - 1) * 0.9)) | floor)],
+            min: $sorted[0],
+            max: $sorted[-1]
+          }
+      end;
+
+    if length == 0 then
+      "summary: count=0"
+    else
+      (stats([.[].base_sec])) as $base_stats
+      | (stats([.[].blacksmith_sec])) as $blacksmith_stats
+      | (stats([.[].delta_sec])) as $delta_stats
+      | "summary(base): count=\($base_stats.count) avg=\($base_stats.avg|round)s median=\($base_stats.median|round)s p90=\($base_stats.p90|round)s min=\($base_stats.min|round)s max=\($base_stats.max|round)s",
+        "summary(blacksmith): count=\($blacksmith_stats.count) avg=\($blacksmith_stats.avg|round)s median=\($blacksmith_stats.median|round)s p90=\($blacksmith_stats.p90|round)s min=\($blacksmith_stats.min|round)s max=\($blacksmith_stats.max|round)s",
+        "summary(delta): count=\($delta_stats.count) avg=\($delta_stats.avg|round)s median=\($delta_stats.median|round)s p90=\($delta_stats.p90|round)s min=\($delta_stats.min|round)s max=\($delta_stats.max|round)s"
+    end
+  ' "$pairs_file"
+}
+
+main() {
+  require_command gh
+  require_command jq
+  require_command column
+
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap "rm -rf '$temp_dir'" EXIT
+
+  local backend_base_json="$temp_dir/backend_base.json"
+  local backend_blacksmith_json="$temp_dir/backend_blacksmith.json"
+  local frontend_base_json="$temp_dir/frontend_base.json"
+  local frontend_blacksmith_json="$temp_dir/frontend_blacksmith.json"
+  local backend_pairs_json="$temp_dir/backend_pairs.json"
+  local frontend_pairs_json="$temp_dir/frontend_pairs.json"
+
+  fetch_runs "$BACKEND_BASE_WORKFLOW" "$backend_base_json"
+  fetch_runs "$BACKEND_BLACKSMITH_WORKFLOW" "$backend_blacksmith_json"
+  build_pairs "backend" "$backend_base_json" "$backend_blacksmith_json" "$backend_pairs_json"
+
+  fetch_runs "$FRONTEND_BASE_WORKFLOW" "$frontend_base_json"
+  fetch_runs "$FRONTEND_BLACKSMITH_WORKFLOW" "$frontend_blacksmith_json"
+  build_pairs "frontend" "$frontend_base_json" "$frontend_blacksmith_json" "$frontend_pairs_json"
+
+  echo "Repository: $REPO"
+  echo "Limit per workflow: $LIMIT"
+  print_report "Backend CI vs Backend CI (Blacksmith)" "$backend_pairs_json"
+  print_report "Frontend CI vs Frontend CI (Blacksmith)" "$frontend_pairs_json"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `Backend CI (Blacksmith)` workflow for PR-based A/B benchmark
- add `Frontend CI (Blacksmith)` workflow for PR-based A/B benchmark
- add `scripts/ci/compare_blacksmith.sh` to compare matched successful runs by `headSha`
- add benchmark log template at `docs/ci/blacksmith-benchmark.md`

## Notes
- existing workflows (`Backend CI`, `Frontend CI`) are kept unchanged
- only the benchmark workflows use `runs-on: blacksmith-4vcpu-ubuntu-2204`
- update runner tag if your Blacksmith dashboard provides a different tag

## Validation
- `bash -n scripts/ci/compare_blacksmith.sh`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each{|f| YAML.load_file(f)}; puts "workflow yaml ok"'`
- `./scripts/ci/compare_blacksmith.sh Ryo-cool/Nature-Spots` (currently returns no pairs until Blacksmith workflow runs exist)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores（開発プロセス改善）**
  * バックエンド／フロントエンド向けの新しいCIワークフローを追加し、テスト実行・ビルド・リンティング・型チェック・アーティファクト収集を自動化しました
  * CIにセキュリティ監査とカバレッジ収集を統合し、成果物をアップロードするようにしました
  * フロントエンドのテスト実行を環境変数で切替可能にし、ベンチマーク手順と比較スクリプトを追加してCI実行時間の測定・比較・報告を可能にしました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->