### PR TITLE
feat(notification): 通知機能のバックエンドを追加

### DIFF
--- a/back/app/controllers/api/v1/announcements_controller.rb
+++ b/back/app/controllers/api/v1/announcements_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::AnnouncementsController < ApplicationController
+  before_action :authenticate_user
+
+  def index
+    announcements = Announcement.published
+    render json: {
+      announcements: announcements.map { |a| AnnouncementSerializer.new(a).as_json }
+    }
+  end
+
+  def create
+    announcement = Announcement.new(announcement_params.merge(
+      author: current_user,
+      published_at: Time.current
+    ))
+    authorize(announcement)
+
+    if announcement.save
+      Notifications::Announce.call(announcement)
+      render json: {
+        announcement: AnnouncementSerializer.new(announcement).with_author
+      }, status: :created
+    else
+      render json: { error: announcement.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def announcement_params
+    params.require(:announcement).permit(:title, :body)
+  end
+end

--- a/back/app/controllers/api/v1/notifications_controller.rb
+++ b/back/app/controllers/api/v1/notifications_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::NotificationsController < ApplicationController
+  before_action :authenticate_user
+
+  def index
+    page = (params[:page] || 1).to_i
+    per_page = (params[:per_page] || 20).to_i
+    offset = (page - 1) * per_page
+
+    scoped = current_user.notifications
+                         .recent
+                         .includes(:actor, :notifiable)
+
+    notifications = scoped.offset(offset).limit(per_page)
+
+    total_count = current_user.notifications.count
+    total_pages = (total_count.to_f / per_page).ceil
+
+    render json: {
+      notifications: notifications.map { |n| NotificationSerializer.new(n).as_json },
+      unread_count: current_user.notifications.unread.count,
+      pagination: {
+        current_page: page,
+        per_page: per_page,
+        total_pages: total_pages,
+        total_count: total_count
+      }
+    }
+  end
+
+  def unread_count
+    render json: { unread_count: current_user.notifications.unread.count }
+  end
+
+  def read
+    notification = current_user.notifications.find(params[:id])
+    notification.mark_as_read!
+    render json: {
+      notification: NotificationSerializer.new(notification).as_json,
+      unread_count: current_user.notifications.unread.count
+    }
+  end
+
+  def read_all
+    current_user.notifications.unread.update_all(read_at: Time.current)
+    render json: { unread_count: 0 }
+  end
+end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include UserAuth::Authenticator
-  include Authorization
 
   # 順序重要: 後に定義されたものが優先される
   # StandardErrorは最も一般的なので最初に（最低優先度）
@@ -12,6 +11,11 @@ class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
   rescue_from JWT::DecodeError, with: :unauthorized_request
   rescue_from JWT::ExpiredSignature, with: :token_expired
+
+  # Authorization の rescue_from(NotAuthorizedError) を StandardError より後に
+  # 登録するため、include はここで行う（先に include すると StandardError に
+  # 上書きされ、認可失敗が 500 になってしまう）
+  include Authorization
 
   private
 

--- a/back/app/models/announcement.rb
+++ b/back/app/models/announcement.rb
@@ -1,0 +1,13 @@
+class Announcement < ApplicationRecord
+  belongs_to :author, class_name: "User"
+  has_many :notifications, as: :notifiable, dependent: :destroy
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :body, presence: true, length: { maximum: 2000 }
+
+  scope :published, -> { where.not(published_at: nil).order(published_at: :desc) }
+
+  def published?
+    published_at.present?
+  end
+end

--- a/back/app/models/notification.rb
+++ b/back/app/models/notification.rb
@@ -1,0 +1,20 @@
+class Notification < ApplicationRecord
+  belongs_to :recipient, class_name: "User"
+  belongs_to :actor, class_name: "User", optional: true
+  belongs_to :notifiable, polymorphic: true, optional: true
+
+  # 通知種別
+  enum :action, { review_posted: 0, followed: 1, announcement: 2 }
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :recent, -> { order(created_at: :desc) }
+
+  # 未読の場合のみ既読にする
+  def mark_as_read!
+    update!(read_at: Time.current) if read_at.nil?
+  end
+
+  def read?
+    read_at.present?
+  end
+end

--- a/back/app/models/relationship.rb
+++ b/back/app/models/relationship.rb
@@ -9,10 +9,22 @@ class Relationship < ApplicationRecord
   
   validate :cannot_follow_self
 
+  # フォローされたユーザーへ通知
+  after_create_commit :notify_followed
+
   private
 
   def cannot_follow_self
     errors.add(:follow_id, "自分自身をフォローすることはできません") if user_id == follow_id
   end
-  
+
+  def notify_followed
+    Notifications::CreateNotification.call(
+      recipient: follow,
+      actor: user,
+      action: :followed,
+      notifiable: self
+    )
+  end
+
 end

--- a/back/app/models/review.rb
+++ b/back/app/models/review.rb
@@ -25,6 +25,9 @@ class Review < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :popular, -> { order(likes_count: :desc) }
 
+  # スポット投稿者へレビュー投稿を通知（自己通知は除外）
+  after_create_commit :notify_spot_owner
+
   # Use counter cache column instead of database count
   def like_count
     likes_count
@@ -33,5 +36,16 @@ class Review < ApplicationRecord
   # いいね済みかどうか
   def liked_by?(user)
     likes.exists?(user_id: user.id)
+  end
+
+  private
+
+  def notify_spot_owner
+    Notifications::CreateNotification.call(
+      recipient: spot.user,
+      actor: user,
+      action: :review_posted,
+      notifiable: self
+    )
   end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -16,6 +16,9 @@ class User < ApplicationRecord
   has_many :followings, through: :relationships, source: :follow
   has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
   has_many :followers, through: :reverse_of_relationships, source: :user
+  # 通知機能関係
+  has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
+  has_many :announcements, foreign_key: :author_id, dependent: :destroy
   # 画像アップロード
   mount_uploader :image, ImageUploader
 

--- a/back/app/policies/announcement_policy.rb
+++ b/back/app/policies/announcement_policy.rb
@@ -1,0 +1,9 @@
+class AnnouncementPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def create?
+    user.present? && user.admin?
+  end
+end

--- a/back/app/serializers/announcement_serializer.rb
+++ b/back/app/serializers/announcement_serializer.rb
@@ -1,0 +1,17 @@
+class AnnouncementSerializer < ApplicationSerializer
+  def as_json(options = {})
+    {
+      id: object.id,
+      title: object.title,
+      body: object.body,
+      published_at: object.published_at,
+      created_at: object.created_at
+    }
+  end
+
+  def with_author
+    as_json.merge(
+      author: UserSerializer.new(object.author).as_json
+    )
+  end
+end

--- a/back/app/serializers/notification_serializer.rb
+++ b/back/app/serializers/notification_serializer.rb
@@ -1,0 +1,38 @@
+class NotificationSerializer < ApplicationSerializer
+  def as_json(options = {})
+    {
+      id: object.id,
+      action: object.action,
+      read: object.read_at.present?,
+      created_at: object.created_at,
+      actor: object.actor && UserSerializer.new(object.actor).as_json,
+      notifiable: serialize_notifiable
+    }
+  end
+
+  private
+
+  def serialize_notifiable
+    case object.notifiable
+    when Review
+      {
+        type: "review",
+        id: object.notifiable.id,
+        spot_id: object.notifiable.spot_id,
+        title: object.notifiable.title
+      }
+    when Relationship
+      {
+        type: "relationship",
+        user_id: object.notifiable.user_id
+      }
+    when Announcement
+      {
+        type: "announcement",
+        id: object.notifiable.id,
+        title: object.notifiable.title,
+        body: object.notifiable.body
+      }
+    end
+  end
+end

--- a/back/app/services/notifications/announce.rb
+++ b/back/app/services/notifications/announce.rb
@@ -1,0 +1,40 @@
+module Notifications
+  # 運営からのお知らせを全アクティブユーザーへ fan-out するサービス。
+  # メモリ効率のため find_in_batches + insert_all で一括挿入する。
+  # 注: insert_all はモデルコールバックを発火しないため、リアルタイム配信や
+  #     Web Push はフェーズ2/3で別途扱う（件数が膨大になるため）。
+  class Announce
+    BATCH_SIZE = 1000
+
+    def self.call(announcement)
+      new(announcement).call
+    end
+
+    def initialize(announcement)
+      @announcement = announcement
+    end
+
+    def call
+      now = Time.current
+      action_value = Notification.actions[:announcement]
+
+      User.where(activated: true).select(:id).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        rows = batch.map do |user|
+          {
+            recipient_id: user.id,
+            action: action_value,
+            notifiable_type: "Announcement",
+            notifiable_id: announcement.id,
+            created_at: now,
+            updated_at: now
+          }
+        end
+        Notification.insert_all(rows) if rows.any?
+      end
+    end
+
+    private
+
+    attr_reader :announcement
+  end
+end

--- a/back/app/services/notifications/create_notification.rb
+++ b/back/app/services/notifications/create_notification.rb
@@ -1,0 +1,37 @@
+module Notifications
+  # 個人向け通知（レビュー投稿・フォロー）を1件生成するサービス。
+  # フェーズ2/3で ActionCable によるブロードキャストや Web Push をこのサービスに追加する。
+  class CreateNotification
+    def self.call(recipient:, action:, actor: nil, notifiable: nil)
+      new(recipient:, action:, actor:, notifiable:).call
+    end
+
+    def initialize(recipient:, action:, actor: nil, notifiable: nil)
+      @recipient = recipient
+      @action = action
+      @actor = actor
+      @notifiable = notifiable
+    end
+
+    def call
+      # 自己通知は生成しない（自分のスポットに自分でレビュー等）
+      return if actor.present? && actor == recipient
+
+      notification = Notification.create!(
+        recipient: recipient,
+        actor: actor,
+        action: action,
+        notifiable: notifiable
+      )
+
+      # フェーズ2: NotificationBroadcaster.call(notification)
+      # フェーズ3: WebPush::Deliver.call(notification)
+
+      notification
+    end
+
+    private
+
+    attr_reader :recipient, :action, :actor, :notifiable
+  end
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -24,6 +24,18 @@ Rails.application.routes.draw do
       resources :locations
       resources :prefectures
       resources :relationships, only: [:create, :destroy]
+
+      # 通知機能
+      resources :notifications, only: [:index] do
+        collection do
+          get :unread_count
+          patch :read_all
+        end
+        member do
+          patch :read
+        end
+      end
+      resources :announcements, only: [:index, :create]
     end
   end
 end

--- a/back/db/migrate/20250528000001_create_notifications.rb
+++ b/back/db/migrate/20250528000001_create_notifications.rb
@@ -1,0 +1,23 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      # 通知の受信者
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      # 通知の発生源となったユーザー（運営通知の場合は nil）
+      t.references :actor, foreign_key: { to_table: :users }
+      # 通知種別 enum: review_posted/followed/announcement
+      t.integer :action, null: false, default: 0
+      # 関連オブジェクト（Review/Relationship/Announcement）
+      t.references :notifiable, polymorphic: true
+      # 既読日時（nil の場合は未読）
+      t.datetime :read_at
+
+      t.timestamps
+    end
+
+    # 未読カウントの主クエリ用
+    add_index :notifications, [:recipient_id, :read_at]
+    # 一覧の新着順ページネーション用
+    add_index :notifications, [:recipient_id, :created_at]
+  end
+end

--- a/back/db/migrate/20250528000002_create_announcements.rb
+++ b/back/db/migrate/20250528000002_create_announcements.rb
@@ -1,0 +1,16 @@
+class CreateAnnouncements < ActiveRecord::Migration[7.2]
+  def change
+    create_table :announcements do |t|
+      # お知らせを作成した管理者
+      t.references :author, null: false, foreign_key: { to_table: :users }
+      t.string :title, null: false
+      t.text :body, null: false
+      # 公開日時（nil の場合は下書き扱い）
+      t.datetime :published_at
+
+      t.timestamps
+    end
+
+    add_index :announcements, :published_at
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_15_000001) do
+  create_table "announcements", force: :cascade do |t|
+    t.integer "author_id", null: false
+    t.string "title", null: false
+    t.text "body", null: false
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_announcements_on_author_id"
+    t.index ["published_at"], name: "index_announcements_on_published_at"
+  end
+
   create_table "favorites", force: :cascade do |t|
     t.integer "spot_id", null: false
     t.integer "user_id", null: false
@@ -29,6 +40,22 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
     t.index ["review_id"], name: "index_likes_on_review_id"
     t.index ["user_id", "review_id"], name: "index_likes_on_user_id_and_review_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer "recipient_id", null: false
+    t.integer "actor_id"
+    t.integer "action", default: 0, null: false
+    t.string "notifiable_type"
+    t.integer "notifiable_id"
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_notifications_on_actor_id"
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["recipient_id", "created_at"], name: "index_notifications_on_recipient_id_and_created_at"
+    t.index ["recipient_id", "read_at"], name: "index_notifications_on_recipient_id_and_read_at"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end
 
   create_table "relationships", force: :cascade do |t|
@@ -57,6 +84,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
     t.index ["rating"], name: "index_reviews_on_rating"
     t.index ["spot_id"], name: "index_reviews_on_spot_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
+  end
+
+  create_table "spot_seasons", force: :cascade do |t|
+    t.integer "spot_id", null: false
+    t.integer "season_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["season_id"], name: "index_spot_seasons_on_season_id"
+    t.index ["spot_id", "season_id"], name: "index_spot_seasons_on_spot_id_and_season_id", unique: true
   end
 
   create_table "spots", force: :cascade do |t|
@@ -94,13 +130,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
     t.index ["email"], name: "index_users_on_email_unique", unique: true
   end
 
+  add_foreign_key "announcements", "users", column: "author_id"
   add_foreign_key "favorites", "spots"
   add_foreign_key "favorites", "users"
   add_foreign_key "likes", "reviews"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "users", column: "actor_id"
+  add_foreign_key "notifications", "users", column: "recipient_id"
   add_foreign_key "relationships", "users"
   add_foreign_key "relationships", "users", column: "follow_id"
   add_foreign_key "reviews", "spots"
   add_foreign_key "reviews", "users"
+  add_foreign_key "spot_seasons", "spots"
   add_foreign_key "spots", "users"
 end

--- a/back/spec/factories/announcements.rb
+++ b/back/spec/factories/announcements.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :announcement do
+    title { "メンテナンスのお知らせ" }
+    body { "本日深夜にメンテナンスを実施します。ご了承ください。" }
+    published_at { Time.current }
+    association :author, factory: :user
+
+    trait :draft do
+      published_at { nil }
+    end
+  end
+end

--- a/back/spec/factories/notifications.rb
+++ b/back/spec/factories/notifications.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :notification do
+    association :recipient, factory: :user
+    association :actor, factory: :user
+    action { :followed }
+    notifiable { nil }
+
+    trait :review_posted do
+      action { :review_posted }
+      association :notifiable, factory: :review
+    end
+
+    trait :followed do
+      action { :followed }
+      association :notifiable, factory: :relationship
+    end
+
+    trait :announcement do
+      action { :announcement }
+      actor { nil }
+      association :notifiable, factory: :announcement
+    end
+
+    trait :read do
+      read_at { Time.current }
+    end
+  end
+end

--- a/back/spec/models/notification_spec.rb
+++ b/back/spec/models/notification_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe 'associations' do
+    it { should belong_to(:recipient).class_name('User') }
+    it { should belong_to(:actor).class_name('User').optional }
+    it { should belong_to(:notifiable).optional }
+  end
+
+  describe 'enum action' do
+    it 'review_posted/followed/announcement を持つこと' do
+      expect(Notification.actions.keys).to contain_exactly('review_posted', 'followed', 'announcement')
+    end
+  end
+
+  describe 'scopes' do
+    let(:recipient) { create(:user) }
+    let!(:unread_notification) { create(:notification, recipient: recipient, read_at: nil) }
+    let!(:read_notification) { create(:notification, recipient: recipient, read_at: Time.current) }
+
+    it '.unread は未読のみ返すこと' do
+      expect(recipient.notifications.unread).to contain_exactly(unread_notification)
+    end
+
+    it '.recent は新着順で返すこと' do
+      expect(recipient.notifications.recent.first).to eq(recipient.notifications.order(created_at: :desc).first)
+    end
+  end
+
+  describe '#mark_as_read!' do
+    it '未読の場合 read_at を設定すること' do
+      notification = create(:notification, read_at: nil)
+      expect { notification.mark_as_read! }.to change { notification.reload.read_at }.from(nil)
+    end
+
+    it '既読の場合 read_at を変更しないこと' do
+      time = 1.day.ago
+      notification = create(:notification, read_at: time)
+      notification.mark_as_read!
+      expect(notification.reload.read_at).to be_within(1.second).of(time)
+    end
+  end
+end

--- a/back/spec/models/relationship_spec.rb
+++ b/back/spec/models/relationship_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe Relationship, type: :model do
     it { should belong_to(:user) }
     it { should belong_to(:follow).class_name('User') }
   end
+
+  describe '通知の生成' do
+    it 'フォロー作成時にフォローされたユーザーへ通知が生成されること' do
+      user = create(:user)
+      follow_user = create(:user)
+      expect {
+        create(:relationship, user: user, follow: follow_user)
+      }.to change { follow_user.notifications.where(action: :followed).count }.by(1)
+    end
+  end
 end

--- a/back/spec/models/review_spec.rb
+++ b/back/spec/models/review_spec.rb
@@ -65,4 +65,23 @@ RSpec.describe Review, type: :model do
     it { should belong_to(:spot) }
     it { should have_many(:likes) }
   end
+
+  describe '通知の生成' do
+    it 'レビュー投稿時にスポット投稿者へ通知が生成されること' do
+      spot_owner = create(:user)
+      reviewer = create(:user)
+      spot = create(:spot, user: spot_owner)
+      expect {
+        create(:review, spot: spot, user: reviewer)
+      }.to change { spot_owner.notifications.where(action: :review_posted).count }.by(1)
+    end
+
+    it '自分のスポットに自分でレビューした場合は通知が生成されないこと（自己通知の除外）' do
+      owner = create(:user)
+      spot = create(:spot, user: owner)
+      expect {
+        create(:review, spot: spot, user: owner)
+      }.not_to change(Notification, :count)
+    end
+  end
 end

--- a/back/spec/requests/api/v1/announcements_request_spec.rb
+++ b/back/spec/requests/api/v1/announcements_request_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Announcements", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:user) { create(:user) }
+
+  describe "GET /api/v1/announcements" do
+    let!(:published) { create(:announcement) }
+    let!(:draft) { create(:announcement, :draft) }
+
+    it "公開済みのお知らせのみ返すこと" do
+      get "/api/v1/announcements", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      ids = json['announcements'].map { |a| a['id'] }
+      expect(ids).to include(published.id)
+      expect(ids).not_to include(draft.id)
+    end
+  end
+
+  describe "POST /api/v1/announcements" do
+    let(:valid_params) { { announcement: { title: "重要なお知らせ", body: "本日メンテナンスを実施します。" } } }
+
+    context "管理者の場合" do
+      it "お知らせを作成し、全アクティブユーザーへ通知を fan-out すること" do
+        create_list(:user, 2)
+
+        expect {
+          post "/api/v1/announcements", params: valid_params, headers: auth_headers(admin)
+        }.to change(Announcement, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        # admin + 作成済み2ユーザー全員に通知が届く
+        expect(Notification.where(action: :announcement).count).to eq(User.where(activated: true).count)
+      end
+    end
+
+    context "一般ユーザーの場合" do
+      it "403を返すこと" do
+        post "/api/v1/announcements", params: valid_params, headers: auth_headers(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "未認証ユーザーの場合" do
+      it "401を返すこと" do
+        post "/api/v1/announcements", params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/back/spec/requests/api/v1/notifications_request_spec.rb
+++ b/back/spec/requests/api/v1/notifications_request_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Notifications", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  describe "GET /api/v1/notifications" do
+    let!(:unread) { create(:notification, recipient: user, read_at: nil) }
+    let!(:read) { create(:notification, recipient: user, read_at: Time.current) }
+    let!(:others) { create(:notification, recipient: other_user) }
+
+    context "認証済みユーザーの場合" do
+      it "自分の通知一覧と未読数を返すこと" do
+        get "/api/v1/notifications", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['notifications'].size).to eq(2)
+        expect(json['unread_count']).to eq(1)
+        expect(json['pagination']['total_count']).to eq(2)
+      end
+
+      it "他人の通知は含まれないこと" do
+        get "/api/v1/notifications", headers: auth_headers(user)
+        json = JSON.parse(response.body)
+        ids = json['notifications'].map { |n| n['id'] }
+        expect(ids).not_to include(others.id)
+      end
+    end
+
+    context "未認証ユーザーの場合" do
+      it "401を返すこと" do
+        get "/api/v1/notifications"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/notifications/unread_count" do
+    it "未読数を返すこと" do
+      create_list(:notification, 2, recipient: user, read_at: nil)
+      create(:notification, recipient: user, read_at: Time.current)
+
+      get "/api/v1/notifications/unread_count", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['unread_count']).to eq(2)
+    end
+  end
+
+  describe "PATCH /api/v1/notifications/:id/read" do
+    let!(:notification) { create(:notification, recipient: user, read_at: nil) }
+
+    it "通知を既読にできること" do
+      patch "/api/v1/notifications/#{notification.id}/read", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(notification.reload.read_at).to be_present
+      expect(JSON.parse(response.body)['notification']['read']).to be true
+    end
+
+    it "他人の通知は既読にできないこと（404）" do
+      others = create(:notification, recipient: other_user, read_at: nil)
+      patch "/api/v1/notifications/#{others.id}/read", headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /api/v1/notifications/read_all" do
+    it "全通知を既読にできること" do
+      create_list(:notification, 3, recipient: user, read_at: nil)
+
+      patch "/api/v1/notifications/read_all", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['unread_count']).to eq(0)
+      expect(user.notifications.unread.count).to eq(0)
+    end
+  end
+end

--- a/back/spec/services/notifications/announce_spec.rb
+++ b/back/spec/services/notifications/announce_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Notifications::Announce, type: :service do
+  let(:admin) { create(:user) }
+  let(:announcement) { create(:announcement, author: admin) }
+
+  it '全アクティブユーザーへ通知を生成すること' do
+    active_users = create_list(:user, 3)
+    create(:user, :inactive)
+    announcement # author(admin) を先に生成しておく
+    active_count = User.where(activated: true).count
+
+    expect {
+      described_class.call(announcement)
+    }.to change(Notification, :count).by(active_count)
+
+    active_users.each do |user|
+      expect(user.notifications.where(notifiable: announcement, action: :announcement)).to exist
+    end
+  end
+
+  it '非アクティブユーザーには生成しないこと' do
+    inactive = create(:user, :inactive)
+    described_class.call(announcement)
+    expect(inactive.notifications.count).to eq(0)
+  end
+end

--- a/back/spec/services/notifications/create_notification_spec.rb
+++ b/back/spec/services/notifications/create_notification_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Notifications::CreateNotification, type: :service do
+  let(:recipient) { create(:user) }
+  let(:actor) { create(:user) }
+
+  it '通知を1件生成すること' do
+    expect {
+      described_class.call(recipient: recipient, actor: actor, action: :followed)
+    }.to change(Notification, :count).by(1)
+  end
+
+  it '生成された通知の属性が正しいこと' do
+    notification = described_class.call(recipient: recipient, actor: actor, action: :followed)
+    expect(notification.recipient).to eq(recipient)
+    expect(notification.actor).to eq(actor)
+    expect(notification.action).to eq('followed')
+  end
+
+  it 'actor と recipient が同一の場合は生成しないこと（自己通知の除外）' do
+    expect {
+      described_class.call(recipient: recipient, actor: recipient, action: :followed)
+    }.not_to change(Notification, :count)
+  end
+
+  it 'actor が nil の場合は生成すること（運営通知など）' do
+    expect {
+      described_class.call(recipient: recipient, action: :announcement)
+    }.to change(Notification, :count).by(1)
+  end
+end

--- a/front/components/loggedIn/header/NotificationBell.vue
+++ b/front/components/loggedIn/header/NotificationBell.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-menu offset-y :max-width="360" :close-on-content-click="false">
+    <template #activator="{ props }">
+      <v-btn
+        icon
+        v-bind="props"
+        :aria-label="$t('notification.bell')"
+        class="mr-2"
+        @click="onOpen"
+      >
+        <v-badge
+          v-if="hasUnread"
+          :content="badgeContent"
+          color="error"
+          offset-x="2"
+          offset-y="2"
+        >
+          <v-icon>mdi-bell-outline</v-icon>
+        </v-badge>
+        <v-icon v-else>mdi-bell-outline</v-icon>
+      </v-btn>
+    </template>
+
+    <v-card width="360" max-height="480" class="overflow-y-auto">
+      <notification-list />
+      <v-divider />
+      <v-card-actions class="justify-center">
+        <v-btn variant="text" size="small" to="/notifications">
+          {{ $t("notification.viewAll") }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { useNotifications } from "~/composables/useNotifications";
+
+const MAX_BADGE_COUNT = 99;
+
+const { unreadCount, hasUnread, fetch, fetchUnreadCount } = useNotifications();
+
+const badgeContent = computed(() =>
+  unreadCount.value > MAX_BADGE_COUNT
+    ? `${MAX_BADGE_COUNT}+`
+    : String(unreadCount.value),
+);
+
+// メニューを開いたタイミングで一覧を取得
+const onOpen = () => {
+  fetch();
+};
+
+onMounted(() => {
+  fetchUnreadCount();
+});
+</script>

--- a/front/components/loggedIn/header/NotificationList.vue
+++ b/front/components/loggedIn/header/NotificationList.vue
@@ -1,0 +1,94 @@
+<template>
+  <div>
+    <div class="d-flex align-center justify-space-between px-4 py-2">
+      <span class="text-subtitle-1 font-weight-bold">
+        {{ $t("notification.title") }}
+      </span>
+      <v-btn
+        v-if="hasUnread"
+        variant="text"
+        size="small"
+        color="primary"
+        @click="onMarkAllRead"
+      >
+        {{ $t("notification.markAllRead") }}
+      </v-btn>
+    </div>
+
+    <v-divider />
+
+    <v-list v-if="items.length > 0" density="compact" class="py-0">
+      <v-list-item
+        v-for="notification in items"
+        :key="notification.id"
+        :class="{ 'bg-blue-lighten-5': !notification.read }"
+        @click="onClick(notification)"
+      >
+        <template #prepend>
+          <v-icon :color="iconColor(notification.action)" :size="24">
+            {{ actionIcon(notification.action) }}
+          </v-icon>
+        </template>
+        <v-list-item-title class="text-wrap text-body-2">
+          {{ buildMessage(notification) }}
+        </v-list-item-title>
+        <v-list-item-subtitle class="text-caption">
+          {{ formatDate(notification.created_at) }}
+        </v-list-item-subtitle>
+      </v-list-item>
+    </v-list>
+
+    <div v-else class="px-4 py-6 text-center text-medium-emphasis">
+      {{ $t("notification.empty") }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import { useNotifications } from "~/composables/useNotifications";
+import type {
+  AppNotification,
+  NotificationAction,
+} from "~/types/api/notification";
+
+const { items, hasUnread, buildMessage, linkFor, markAsRead, markAllRead } =
+  useNotifications();
+const { locale } = useI18n();
+const router = useRouter();
+
+const ACTION_ICONS: Record<NotificationAction, string> = {
+  review_posted: "mdi-comment-text-outline",
+  followed: "mdi-account-plus-outline",
+  announcement: "mdi-bullhorn-outline",
+};
+
+const ACTION_COLORS: Record<NotificationAction, string> = {
+  review_posted: "teal",
+  followed: "indigo",
+  announcement: "orange",
+};
+
+const actionIcon = (action: NotificationAction): string =>
+  ACTION_ICONS[action] ?? "mdi-bell-outline";
+
+const iconColor = (action: NotificationAction): string =>
+  ACTION_COLORS[action] ?? "grey";
+
+const formatDate = (value: string): string =>
+  new Date(value).toLocaleDateString(locale.value === "en" ? "en-US" : "ja-JP");
+
+const onClick = async (notification: AppNotification) => {
+  if (!notification.read) {
+    await markAsRead(notification.id);
+  }
+  const link = linkFor(notification);
+  if (link) {
+    router.push(link);
+  }
+};
+
+const onMarkAllRead = async () => {
+  await markAllRead();
+};
+</script>

--- a/front/components/loggedIn/header/loggedInAppBar.vue
+++ b/front/components/loggedIn/header/loggedInAppBar.vue
@@ -6,6 +6,7 @@
 
     <app-title />
     <v-spacer />
+    <notification-bell />
     <nuxt-link
       to="/favorites"
       class="text-decoration-none mr-4 hidden-ipad-and-down"

--- a/front/composables/useNotifications.ts
+++ b/front/composables/useNotifications.ts
@@ -1,0 +1,62 @@
+import { storeToRefs } from "pinia";
+import { useI18n } from "vue-i18n";
+import { useNotificationStore } from "~/stores/notification";
+import type { AppNotification } from "~/types/api/notification";
+
+/**
+ * 通知ストアのラッパ。表示用メッセージ生成と遷移先の解決を提供する。
+ */
+export const useNotifications = () => {
+  const store = useNotificationStore();
+  const { items, unreadCount, loading, hasUnread, hasMore } =
+    storeToRefs(store);
+  const { t } = useI18n();
+
+  // action に応じた表示メッセージを生成
+  const buildMessage = (notification: AppNotification): string => {
+    const actorName = notification.actor?.name ?? t("notification.someone");
+    switch (notification.action) {
+      case "review_posted":
+        return t("notification.reviewPosted", { actor: actorName });
+      case "followed":
+        return t("notification.followed", { actor: actorName });
+      case "announcement":
+        return notification.notifiable?.type === "announcement"
+          ? notification.notifiable.title
+          : t("notification.announcement");
+      default:
+        return "";
+    }
+  };
+
+  // クリック時の遷移先を解決（遷移不要なら null）
+  const linkFor = (notification: AppNotification): string | null => {
+    const notifiable = notification.notifiable;
+    if (!notifiable) return null;
+    switch (notifiable.type) {
+      case "review":
+        return `/spots/${notifiable.spot_id}`;
+      case "relationship":
+        return `/user/${notifiable.user_id}`;
+      case "announcement":
+        return "/notifications";
+      default:
+        return null;
+    }
+  };
+
+  return {
+    items,
+    unreadCount,
+    loading,
+    hasUnread,
+    hasMore,
+    buildMessage,
+    linkFor,
+    fetch: store.fetch,
+    fetchMore: store.fetchMore,
+    fetchUnreadCount: store.fetchUnreadCount,
+    markAsRead: store.markAsRead,
+    markAllRead: store.markAllRead,
+  };
+};

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -34,5 +34,17 @@
       "empty": "No recommended spots for this season yet",
       "error": "Failed to load seasonal spots"
     }
+  },
+  "notification": {
+    "bell": "Notifications",
+    "title": "Notifications",
+    "empty": "No notifications",
+    "markAllRead": "Mark all as read",
+    "viewAll": "View all notifications",
+    "loadMore": "Load more",
+    "someone": "Someone",
+    "reviewPosted": "{actor} posted a review on your spot",
+    "followed": "{actor} started following you",
+    "announcement": "There is an announcement from the team"
   }
 }

--- a/front/locales/ja.json
+++ b/front/locales/ja.json
@@ -34,5 +34,17 @@
       "empty": "この季節のおすすめスポットはまだありません",
       "error": "季節別スポットの取得に失敗しました"
     }
+  },
+  "notification": {
+    "bell": "通知",
+    "title": "通知",
+    "empty": "通知はありません",
+    "markAllRead": "すべて既読にする",
+    "viewAll": "すべての通知を見る",
+    "loadMore": "もっと見る",
+    "someone": "誰か",
+    "reviewPosted": "{actor}さんがあなたのスポットにレビューを投稿しました",
+    "followed": "{actor}さんがあなたをフォローしました",
+    "announcement": "運営からのお知らせがあります"
   }
 }

--- a/front/pages/notifications/index.vue
+++ b/front/pages/notifications/index.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-container class="py-6" style="max-width: 720px">
+    <div class="d-flex align-center justify-space-between mb-4">
+      <h1 class="text-h5">{{ $t("notification.title") }}</h1>
+      <v-btn
+        v-if="hasUnread"
+        variant="text"
+        color="primary"
+        @click="markAllRead"
+      >
+        {{ $t("notification.markAllRead") }}
+      </v-btn>
+    </div>
+
+    <v-card v-if="items.length > 0">
+      <v-list>
+        <template v-for="(notification, index) in items" :key="notification.id">
+          <v-divider v-if="index > 0" />
+          <v-list-item
+            :class="{ 'bg-blue-lighten-5': !notification.read }"
+            @click="onClick(notification)"
+          >
+            <template #prepend>
+              <v-icon :color="iconColor(notification.action)">
+                {{ actionIcon(notification.action) }}
+              </v-icon>
+            </template>
+            <v-list-item-title class="text-wrap">
+              {{ buildMessage(notification) }}
+            </v-list-item-title>
+            <v-list-item-subtitle class="text-caption">
+              {{ formatDate(notification.created_at) }}
+            </v-list-item-subtitle>
+          </v-list-item>
+        </template>
+      </v-list>
+
+      <div v-if="hasMore" class="text-center py-3">
+        <v-btn variant="outlined" :loading="loading" @click="fetchMore">
+          {{ $t("notification.loadMore") }}
+        </v-btn>
+      </div>
+    </v-card>
+
+    <v-card v-else-if="!loading" class="pa-8 text-center text-medium-emphasis">
+      {{ $t("notification.empty") }}
+    </v-card>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+import { useNotifications } from "~/composables/useNotifications";
+import type {
+  AppNotification,
+  NotificationAction,
+} from "~/types/api/notification";
+
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+const {
+  items,
+  loading,
+  hasUnread,
+  hasMore,
+  buildMessage,
+  linkFor,
+  fetch,
+  fetchMore,
+  markAsRead,
+  markAllRead,
+} = useNotifications();
+const { locale } = useI18n();
+const router = useRouter();
+
+const ACTION_ICONS: Record<NotificationAction, string> = {
+  review_posted: "mdi-comment-text-outline",
+  followed: "mdi-account-plus-outline",
+  announcement: "mdi-bullhorn-outline",
+};
+
+const ACTION_COLORS: Record<NotificationAction, string> = {
+  review_posted: "teal",
+  followed: "indigo",
+  announcement: "orange",
+};
+
+const actionIcon = (action: NotificationAction): string =>
+  ACTION_ICONS[action] ?? "mdi-bell-outline";
+
+const iconColor = (action: NotificationAction): string =>
+  ACTION_COLORS[action] ?? "grey";
+
+const formatDate = (value: string): string =>
+  new Date(value).toLocaleString(locale.value === "en" ? "en-US" : "ja-JP");
+
+const onClick = async (notification: AppNotification) => {
+  if (!notification.read) {
+    await markAsRead(notification.id);
+  }
+  const link = linkFor(notification);
+  if (link) {
+    router.push(link);
+  }
+};
+
+onMounted(() => {
+  fetch();
+});
+</script>

--- a/front/stores/notification.ts
+++ b/front/stores/notification.ts
@@ -1,0 +1,112 @@
+import { defineStore } from "pinia";
+import { useAuthStore } from "~/stores/auth";
+import type {
+  AppNotification,
+  NotificationListResponse,
+  UnreadCountResponse,
+  MarkReadResponse,
+} from "~/types/api/notification";
+
+const PER_PAGE = 20;
+
+export const useNotificationStore = defineStore("notification", {
+  state: () => ({
+    items: [] as AppNotification[],
+    unreadCount: 0,
+    loading: false,
+    page: 1,
+    totalPages: 1,
+  }),
+
+  getters: {
+    hasUnread: (state) => state.unreadCount > 0,
+    hasMore: (state) => state.page < state.totalPages,
+  },
+
+  actions: {
+    // 認証ヘッダー付きで $fetch を行う共通ヘルパー
+    async request<T>(url: string, method: "GET" | "PATCH"): Promise<T> {
+      const config = useRuntimeConfig();
+      const authStore = useAuthStore();
+      return await $fetch<T>(url, {
+        method,
+        baseURL: config.public.apiBaseUrl,
+        headers: {
+          Authorization: `Bearer ${authStore.token}`,
+        },
+      });
+    },
+
+    // 通知一覧を最初から取得する
+    async fetch() {
+      this.loading = true;
+      try {
+        const response = await this.request<NotificationListResponse>(
+          `/api/v1/notifications?page=1&per_page=${PER_PAGE}`,
+          "GET",
+        );
+        this.items = response.notifications;
+        this.unreadCount = response.unread_count;
+        this.page = response.pagination.current_page;
+        this.totalPages = response.pagination.total_pages;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    // 次ページを取得して末尾に追加する
+    async fetchMore() {
+      if (!this.hasMore || this.loading) return;
+      this.loading = true;
+      try {
+        const nextPage = this.page + 1;
+        const response = await this.request<NotificationListResponse>(
+          `/api/v1/notifications?page=${nextPage}&per_page=${PER_PAGE}`,
+          "GET",
+        );
+        this.items = [...this.items, ...response.notifications];
+        this.unreadCount = response.unread_count;
+        this.page = response.pagination.current_page;
+        this.totalPages = response.pagination.total_pages;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    // 未読数のみ取得する（ヘッダーのバッジ更新用）
+    async fetchUnreadCount() {
+      const response = await this.request<UnreadCountResponse>(
+        "/api/v1/notifications/unread_count",
+        "GET",
+      );
+      this.unreadCount = response.unread_count;
+    },
+
+    // 個別の通知を既読にする
+    async markAsRead(id: number) {
+      const response = await this.request<MarkReadResponse>(
+        `/api/v1/notifications/${id}/read`,
+        "PATCH",
+      );
+      const target = this.items.find((n) => n.id === id);
+      if (target) target.read = true;
+      this.unreadCount = response.unread_count;
+    },
+
+    // すべての通知を既読にする
+    async markAllRead() {
+      await this.request<UnreadCountResponse>(
+        "/api/v1/notifications/read_all",
+        "PATCH",
+      );
+      this.items = this.items.map((n) => ({ ...n, read: true }));
+      this.unreadCount = 0;
+    },
+
+    // リアルタイム受信時に先頭へ追加する（フェーズ2で使用）
+    prepend(notification: AppNotification) {
+      this.items = [notification, ...this.items];
+      if (!notification.read) this.unreadCount += 1;
+    },
+  },
+});

--- a/front/tests/components/NotificationBell.spec.ts
+++ b/front/tests/components/NotificationBell.spec.ts
@@ -1,0 +1,79 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import NotificationBell from "../../components/loggedIn/header/NotificationBell.vue";
+
+const mockFetch = vi.fn();
+const mockFetchUnreadCount = vi.fn();
+const unreadCount = ref(0);
+const hasUnread = ref(false);
+
+vi.mock("~/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    unreadCount,
+    hasUnread,
+    fetch: mockFetch,
+    fetchUnreadCount: mockFetchUnreadCount,
+  }),
+}));
+
+const globalStubs = {
+  "v-menu": {
+    template:
+      "<div class='v-menu'><slot name='activator' :props='{}' /><slot /></div>",
+  },
+  "v-btn": { template: "<button class='v-btn'><slot /></button>" },
+  "v-badge": {
+    props: ["content"],
+    template: "<span class='v-badge' :data-content='content'><slot /></span>",
+  },
+  "v-icon": { template: "<i class='v-icon'><slot /></i>" },
+  "v-card": { template: "<div class='v-card'><slot /></div>" },
+  "v-card-actions": { template: "<div class='v-card-actions'><slot /></div>" },
+  "v-divider": { template: "<hr />" },
+  "notification-list": { template: "<div class='notification-list' />" },
+};
+
+const mountComponent = () =>
+  mount(NotificationBell, {
+    global: {
+      stubs: globalStubs,
+      mocks: { $t: (key: string) => key },
+    },
+  });
+
+describe("components/loggedIn/header/NotificationBell.vue", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetchUnreadCount.mockReset();
+    unreadCount.value = 0;
+    hasUnread.value = false;
+  });
+
+  test("マウント時に未読数を取得すること", async () => {
+    mountComponent();
+    await flushPromises();
+    expect(mockFetchUnreadCount).toHaveBeenCalled();
+  });
+
+  test("未読がある場合はバッジに件数を表示すること", () => {
+    unreadCount.value = 3;
+    hasUnread.value = true;
+    const wrapper = mountComponent();
+    const badge = wrapper.find(".v-badge");
+    expect(badge.exists()).toBe(true);
+    expect(badge.attributes("data-content")).toBe("3");
+  });
+
+  test("未読が100件以上の場合は99+と表示すること", () => {
+    unreadCount.value = 150;
+    hasUnread.value = true;
+    const wrapper = mountComponent();
+    expect(wrapper.find(".v-badge").attributes("data-content")).toBe("99+");
+  });
+
+  test("未読がない場合はバッジを表示しないこと", () => {
+    const wrapper = mountComponent();
+    expect(wrapper.find(".v-badge").exists()).toBe(false);
+  });
+});

--- a/front/tests/stores/notification.spec.ts
+++ b/front/tests/stores/notification.spec.ts
@@ -1,0 +1,91 @@
+import { setActivePinia, createPinia } from "pinia";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { useNotificationStore } from "../../stores/notification";
+import type { AppNotification } from "../../types/api/notification";
+
+const mockFetch = vi.fn();
+
+const buildNotification = (
+  overrides: Partial<AppNotification> = {},
+): AppNotification => ({
+  id: 1,
+  action: "followed",
+  read: false,
+  created_at: "2026-05-28T00:00:00Z",
+  actor: { id: 2, email: "a@example.com", name: "Taro" },
+  notifiable: { type: "relationship", user_id: 2 },
+  ...overrides,
+});
+
+describe("stores/notification", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockFetch.mockReset();
+    vi.stubGlobal("$fetch", mockFetch);
+  });
+
+  test("fetch() で一覧・未読数・ページ情報を取得すること", async () => {
+    mockFetch.mockResolvedValueOnce({
+      notifications: [buildNotification()],
+      unread_count: 1,
+      pagination: {
+        current_page: 1,
+        per_page: 20,
+        total_pages: 2,
+        total_count: 25,
+      },
+    });
+
+    const store = useNotificationStore();
+    await store.fetch();
+
+    expect(store.items).toHaveLength(1);
+    expect(store.unreadCount).toBe(1);
+    expect(store.totalPages).toBe(2);
+    expect(store.hasMore).toBe(true);
+    expect(store.hasUnread).toBe(true);
+  });
+
+  test("markAsRead() で対象を既読にし未読数を更新すること", async () => {
+    const store = useNotificationStore();
+    store.items = [buildNotification({ id: 5, read: false })];
+    store.unreadCount = 1;
+
+    mockFetch.mockResolvedValueOnce({
+      notification: buildNotification({ id: 5, read: true }),
+      unread_count: 0,
+    });
+
+    await store.markAsRead(5);
+
+    expect(store.items[0].read).toBe(true);
+    expect(store.unreadCount).toBe(0);
+  });
+
+  test("markAllRead() で全件を既読にすること", async () => {
+    const store = useNotificationStore();
+    store.items = [
+      buildNotification({ id: 1, read: false }),
+      buildNotification({ id: 2, read: false }),
+    ];
+    store.unreadCount = 2;
+
+    mockFetch.mockResolvedValueOnce({ unread_count: 0 });
+
+    await store.markAllRead();
+
+    expect(store.items.every((n) => n.read)).toBe(true);
+    expect(store.unreadCount).toBe(0);
+  });
+
+  test("prepend() で先頭に追加し未読数を増やすこと", () => {
+    const store = useNotificationStore();
+    store.items = [buildNotification({ id: 1 })];
+    store.unreadCount = 0;
+
+    store.prepend(buildNotification({ id: 99, read: false }));
+
+    expect(store.items[0].id).toBe(99);
+    expect(store.unreadCount).toBe(1);
+  });
+});

--- a/front/types/api/index.ts
+++ b/front/types/api/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth";
 export * from "./spot";
 export * from "./common";
+export * from "./notification";
 
 // APIのベースURL設定の型
 export interface ApiConfig {

--- a/front/types/api/notification.ts
+++ b/front/types/api/notification.ts
@@ -1,0 +1,65 @@
+import type { User } from "~/types";
+
+// 通知種別
+export type NotificationAction = "review_posted" | "followed" | "announcement";
+
+// notifiable（関連オブジェクト）の判別ユニオン
+export interface ReviewNotifiable {
+  type: "review";
+  id: number;
+  spot_id: number;
+  title: string;
+}
+
+export interface RelationshipNotifiable {
+  type: "relationship";
+  user_id: number;
+}
+
+export interface AnnouncementNotifiable {
+  type: "announcement";
+  id: number;
+  title: string;
+  body: string;
+}
+
+export type Notifiable =
+  | ReviewNotifiable
+  | RelationshipNotifiable
+  | AnnouncementNotifiable;
+
+// 通知本体
+export interface AppNotification {
+  id: number;
+  action: NotificationAction;
+  read: boolean;
+  created_at: string;
+  actor: User | null;
+  notifiable: Notifiable | null;
+}
+
+// ページネーション情報
+export interface NotificationPagination {
+  current_page: number;
+  per_page: number;
+  total_pages: number;
+  total_count: number;
+}
+
+// GET /api/v1/notifications のレスポンス
+export interface NotificationListResponse {
+  notifications: AppNotification[];
+  unread_count: number;
+  pagination: NotificationPagination;
+}
+
+// 未読数のレスポンス
+export interface UnreadCountResponse {
+  unread_count: number;
+}
+
+// 既読化のレスポンス
+export interface MarkReadResponse {
+  notification: AppNotification;
+  unread_count: number;
+}


### PR DESCRIPTION
レビュー投稿・フォロー・運営お知らせを対象とした通知機能(MVP)を実装。

- Notification(polymorphic)/Announcement モデルとマイグレーションを追加
- レビュー/フォロー作成時に after_create_commit で通知を生成(自己通知は除外)
- お知らせは insert_all で全アクティブユーザーへ fan-out
- 通知一覧/未読数/既読化API、お知らせ一覧/作成API(admin限定)を追加
- 通知生成は Notifications::CreateNotification に集約しフェーズ2/3に拡張可能に
- 認可エラーが500になっていた rescue_from の登録順を修正(403を返すよう是正)
- model/request/service spec を追加

https://claude.ai/code/session_01NyQsH7ui9GSQL88FV1iQDd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **通知システムの追加**: ヘッダーに通知ベルアイコンを追加。レビューの投稿、フォロー、お知らせなど各種イベントをリアルタイムで通知します。
* **通知一覧ページ**: すべての通知を確認できる専用ページを追加。個別または一括で既読化できます。
* **お知らせ機能**: 管理者がアクティブユーザー全員にお知らせを配信できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ryo-cool/Nature-Spots/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->