### PR TITLE
fix: Phase1 Critical（認可穴・レガシーAPI除去・schema同期）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ front/.nitro
 front/dist
 front/node_modules
 front/.cache
+# Bundler local path
+/back/vendor/bundle/

--- a/back/app/controllers/api/v1/locations_controller.rb
+++ b/back/app/controllers/api/v1/locations_controller.rb
@@ -1,31 +1,38 @@
 class Api::V1::LocationsController < ApplicationController
   before_action :set_location, only: [:show]
-  before_action :set_spot, only: [:show]
-  # before_action :set_prefecture, only: [:show]
+
   def index
-    @locations= Location.all
+    @locations = Location.all
     render json: @locations
   end
 
   def show
-    @jspot= Spot.where(location_id: @location.id)
-    @prefecture = Spot.includes(:prefecture)
-    @prefecture= Prefecture.all
-    render json:{
-      location: @location,
-      spot: @jspot,
-      prefecture: @prefecture
-    } 
+    @spots = Spot.where(location_id: @location.id)
+    @prefectures = Prefecture.all
+    render json: {
+      location: serialize_active_hash(@location),
+      spot: @spots,
+      prefecture: @prefectures.map { |p| serialize_active_hash(p) }
+    }
   end
 
   private
 
   def set_location
-    @location = Location.find(params[:id])
+    @location = Location.find_by(id: params[:id])
+    raise ActiveRecord::RecordNotFound.new("Couldn't find Location", "Location") if @location.nil?
   end
 
-  def set_spot
-    @spot = Spot.find(params[:id])
-  end
+  def serialize_active_hash(resource)
+    return nil if resource.blank?
 
+    {
+      id: resource.id,
+      type: resource.class.name.demodulize.underscore,
+      attributes: {
+        id: resource.id,
+        name: resource.name
+      }
+    }
+  end
 end

--- a/back/app/controllers/api/v1/prefectures_controller.rb
+++ b/back/app/controllers/api/v1/prefectures_controller.rb
@@ -1,25 +1,36 @@
 class Api::V1::PrefecturesController < ApplicationController
   before_action :set_prefecture, only: [:show]
-  # before_action :set_spot, only: [:show]
 
   def index
-    @prefectures= Prefecture.all
+    @prefectures = Prefecture.all
     render json: @prefectures
   end
 
   def show
-    @pspot= Spot.where(prefecture_id: @prefecture.id)
-    render json:{prefecture: @prefecture,spot: @pspot} 
+    @spots = Spot.where(prefecture_id: @prefecture.id)
+    render json: {
+      prefecture: serialize_active_hash(@prefecture),
+      spot: @spots
+    }
   end
 
   private
 
   def set_prefecture
-    @prefecture = Prefecture.find(params[:id])
+    @prefecture = Prefecture.find_by(id: params[:id])
+    raise ActiveRecord::RecordNotFound.new("Couldn't find Prefecture", "Prefecture") if @prefecture.nil?
   end
 
-  # def set_spot
-  #   @spot = Spot.find(params[:id])
-  # end
+  def serialize_active_hash(resource)
+    return nil if resource.blank?
 
+    {
+      id: resource.id,
+      type: resource.class.name.demodulize.underscore,
+      attributes: {
+        id: resource.id,
+        name: resource.name
+      }
+    }
+  end
 end

--- a/back/app/controllers/api/v1/relationships_controller.rb
+++ b/back/app/controllers/api/v1/relationships_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::RelationshipsController < ApplicationController
   before_action :set_user
 
   def create
-    @relationship = current_user.active_relationships.build(follow_id: @user.id)
+    @relationship = current_user.relationships.build(follow_id: @user.id)
     if @relationship.save
       render json: {
         relationship: RelationshipSerializer.new(@relationship).as_json,
@@ -15,7 +15,7 @@ class Api::V1::RelationshipsController < ApplicationController
   end
 
   def destroy
-    @relationship = current_user.active_relationships.find_by!(follow_id: @user.id)
+    @relationship = current_user.relationships.find_by!(follow_id: @user.id)
     @relationship.destroy!
     render json: {
       message: "フォローを解除しました",

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,10 +1,30 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_user
+  before_action :authenticate_user, except: [:create]
   before_action :set_user, only: [:show, :update]
 
+  def create
+    @user = User.new(create_user_params)
+    @user.activated = true
+
+    if @user.save
+      serialized_user = UserSerializer.new(@user).as_json
+      render json: {
+        user: serialized_user,
+        status: :created
+      }, status: :created
+    else
+      render json: {
+        errors: @user.errors.messages,
+        message: @user.errors.full_messages.first,
+        status: :unprocessable_entity
+      }, status: :unprocessable_entity
+    end
+  end
+
   def show
+    authorize @user
     result = UserDataService.call(@user)
-    
+
     if result.success?
       render json: {
         **result.data,
@@ -19,6 +39,8 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def update
+    authorize @user
+
     if @user.update(user_params)
       serialized_user = UserSerializer.new(@user).as_json
       render json: {
@@ -43,7 +65,7 @@ class Api::V1::UsersController < ApplicationController
 
   def user_data
     result = UserDataService.call(current_user)
-    
+
     if result.success?
       render json: {
         **result.data,
@@ -61,6 +83,10 @@ class Api::V1::UsersController < ApplicationController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def create_user_params
+    params.permit(:name, :email, :password, :password_confirmation)
   end
 
   def user_params

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -12,12 +12,19 @@ class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
   rescue_from JWT::DecodeError, with: :unauthorized_request
   rescue_from JWT::ExpiredSignature, with: :token_expired
+  # StandardErrorより後に定義し、認可エラーが500にならないようにする
+  rescue_from Authorization::NotAuthorizedError, with: :user_not_authorized
 
   private
 
   def record_not_found(exception)
+    model_name = if exception.respond_to?(:model) && exception.model.present?
+                   exception.model
+                 else
+                   "Resource"
+                 end
     render json: {
-      error: "#{exception.model} not found",
+      error: "#{model_name} not found",
       status: :not_found
     }, status: :not_found
   end
@@ -39,21 +46,21 @@ class ApplicationController < ActionController::API
   def internal_server_error(exception)
     Rails.logger.error "Internal Server Error: #{exception.message}"
     Rails.logger.error exception.backtrace.join("\n")
-    
+
     render json: {
       error: "内部サーバーエラーが発生しました",
       status: :internal_server_error
     }, status: :internal_server_error
   end
 
-  def unauthorized_request(exception)
+  def unauthorized_request(_exception)
     render json: {
       error: "認証に失敗しました",
       status: :unauthorized
     }, status: :unauthorized
   end
 
-  def token_expired(exception)
+  def token_expired(_exception)
     render json: {
       error: "トークンの有効期限が切れています",
       status: :unauthorized

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -1,0 +1,29 @@
+class UserPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    user.present? && owner?
+  end
+
+  def destroy?
+    user.present? && owner?
+  end
+
+  private
+
+  def owner?
+    record == user
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_15_000001) do
   create_table "favorites", force: :cascade do |t|
     t.integer "spot_id", null: false
     t.integer "user_id", null: false
@@ -59,6 +59,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "spot_seasons", force: :cascade do |t|
+    t.integer "spot_id", null: false
+    t.integer "season_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["season_id"], name: "index_spot_seasons_on_season_id"
+    t.index ["spot_id", "season_id"], name: "index_spot_seasons_on_spot_id_and_season_id", unique: true
+  end
+
   create_table "spots", force: :cascade do |t|
     t.string "name"
     t.text "introduction"
@@ -102,5 +111,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_000001) do
   add_foreign_key "relationships", "users", column: "follow_id"
   add_foreign_key "reviews", "spots"
   add_foreign_key "reviews", "users"
+  add_foreign_key "spot_seasons", "spots"
   add_foreign_key "spots", "users"
 end

--- a/back/spec/requests/api/v1/locations_request_spec.rb
+++ b/back/spec/requests/api/v1/locations_request_spec.rb
@@ -1,5 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Locations", type: :request do
+  let(:user) { create(:user) }
+  let!(:spot) { create(:spot, user: user, location_id: 1, prefecture_id: 13) }
 
+  describe "GET /api/v1/locations" do
+    it "ロケーション一覧を取得できること" do
+      get "/api/v1/locations"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to be_an(Array)
+      first = json.first
+      expect(first['attributes'] || first).to include('id' => 1, 'name' => '海')
+    end
+  end
+
+  describe "GET /api/v1/locations/:id" do
+    it "ロケーションに紐づくスポットを取得できること" do
+      get "/api/v1/locations/1"
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['location']['attributes']['name']).to eq('海')
+      expect(json['spot'].map { |s| s['id'] }).to include(spot.id)
+      expect(json['prefecture']).to be_an(Array)
+    end
+
+    it "存在しないロケーションの場合は404を返すこと" do
+      get "/api/v1/locations/999"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/back/spec/requests/api/v1/prefectures_request_spec.rb
+++ b/back/spec/requests/api/v1/prefectures_request_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Prefectures", type: :request do
+  let(:user) { create(:user) }
+  let!(:spot) { create(:spot, user: user, prefecture_id: 13, location_id: 1) }
 
+  describe "GET /api/v1/prefectures" do
+    it "都道府県一覧を取得できること" do
+      get "/api/v1/prefectures"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to be_an(Array)
+      expect(json.size).to eq(47)
+    end
+  end
+
+  describe "GET /api/v1/prefectures/:id" do
+    it "都道府県に紐づくスポットを取得できること" do
+      get "/api/v1/prefectures/13"
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['prefecture']['attributes']['name']).to eq('東京都')
+      expect(json['spot'].map { |s| s['id'] }).to include(spot.id)
+    end
+  end
 end

--- a/back/spec/requests/api/v1/relationships_request_spec.rb
+++ b/back/spec/requests/api/v1/relationships_request_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Relationships", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:headers) { auth_headers(user) }
 
+  describe "POST /api/v1/relationships" do
+    it "フォローできること" do
+      expect {
+        post "/api/v1/relationships", params: { follow_id: other_user.id }, headers: headers
+      }.to change(Relationship, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['relationship']).to be_present
+      expect(json['user']['id']).to eq(other_user.id)
+    end
+
+    it "未認証の場合は401を返すこと" do
+      post "/api/v1/relationships", params: { follow_id: other_user.id }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "DELETE /api/v1/relationships/:id" do
+    before { user.follow(other_user) }
+
+    it "フォロー解除できること" do
+      expect {
+        delete "/api/v1/relationships/#{other_user.id}",
+               params: { follow_id: other_user.id },
+               headers: headers
+      }.to change(Relationship, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/back/spec/requests/api/v1/user_request_spec.rb
+++ b/back/spec/requests/api/v1/user_request_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Users", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:headers) { auth_headers(user) }
 
+  describe "POST /api/v1/users" do
+    let(:valid_params) do
+      {
+        name: "新規ユーザー",
+        email: "newuser@example.com",
+        password: "Password123"
+      }
+    end
+
+    it "ユーザーを作成できること" do
+      expect {
+        post "/api/v1/users", params: valid_params
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['user']['email']).to eq("newuser@example.com")
+      expect(User.find_by(email: "newuser@example.com").activated).to be true
+    end
+
+    it "不正なパラメータの場合は422を返すこと" do
+      post "/api/v1/users", params: { name: "a", email: "bad", password: "short" }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /api/v1/users/:id" do
+    it "ユーザーデータを取得できること" do
+      get "/api/v1/users/#{other_user.id}", headers: headers
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['user']['id']).to eq(other_user.id)
+    end
+  end
+
+  describe "PATCH /api/v1/users/:id" do
+    it "本人は更新できること" do
+      patch "/api/v1/users/#{user.id}",
+            params: { name: "更新後ネーム", introduction: "自己紹介" },
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.name).to eq("更新後ネーム")
+    end
+
+    it "他人の更新は403を返すこと" do
+      patch "/api/v1/users/#{other_user.id}",
+            params: { name: "不正更新" },
+            headers: headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(other_user.reload.name).not_to eq("不正更新")
+    end
+
+    it "未認証の場合は401を返すこと" do
+      patch "/api/v1/users/#{user.id}", params: { name: "更新" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/v1/users/user_data" do
+    it "自分のユーザーデータを取得できること" do
+      get "/api/v1/users/user_data", headers: headers
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['user']['id']).to eq(user.id)
+      expect(json).to include('reviews', 'liked_reviews', 'favorites', 'followings', 'followers')
+    end
+  end
 end

--- a/front/components/spot/spotData.vue
+++ b/front/components/spot/spotData.vue
@@ -79,22 +79,19 @@
       </h3>
       <v-row>
         <v-col>
-          <GmapMap
-            v-if="spot?.latitude && spot?.longitude"
-            ref="mapRef"
-            :center="{ lat: spot.latitude, lng: spot.longitude }"
+          <GoogleMap
+            v-if="mapCenter && googleMapsKey"
+            :api-key="googleMapsKey"
+            :center="mapCenter"
             :zoom="12"
             style="width: 100%; height: 300px"
           >
-            <GmapMarker
+            <Marker
               v-for="(m, id) in markerItems"
               :key="id"
-              :position="{ lat: spot.latitude, lng: spot.longitude }"
-              :title="m.title"
-              :clickable="true"
-              :draggable="false"
+              :options="{ position: m.position, title: m.title }"
             />
-          </GmapMap>
+          </GoogleMap>
         </v-col>
       </v-row>
     </v-container>
@@ -105,6 +102,7 @@
 import { ref, onMounted, computed } from "vue";
 import { useRoute } from "vue-router";
 import type { Ref } from "vue";
+import { GoogleMap, Marker } from "vue3-google-map";
 import { useAuthStore } from "~/stores/auth";
 import { useToastStore } from "~/stores/toast";
 import { useApi } from "~/composables/useApi";
@@ -123,10 +121,28 @@ interface MarkerItem {
   title: string;
 }
 
+interface ActiveHashResource {
+  attributes?: {
+    name?: string;
+  };
+}
+
+interface SpotShowResponse {
+  spot?: Spot;
+  prefecture?: ActiveHashResource;
+  location?: ActiveHashResource;
+  favuser?: number | null;
+  reviews_count?: number;
+  average_rating?: number;
+}
+
 const route = useRoute();
 const authStore = useAuthStore();
 const toastStore = useToastStore();
 const $api = useApi();
+const { $googleMapsKey } = useNuxtApp();
+
+const googleMapsKey = typeof $googleMapsKey === "string" ? $googleMapsKey : "";
 
 const spot: Ref<Spot | null> = ref(null);
 const favUserId: Ref<number | null> = ref(null);
@@ -136,11 +152,13 @@ const rating = ref(2.6);
 const reviewCount = ref(0);
 const alert = ref(false);
 const likeDelete = ref(false);
-const mapRef = ref(null);
 
-const markerItems: Ref<MarkerItem[]> = ref([
-  { position: { lat: 35.71, lng: 139.72 }, title: "marker_1" },
-]);
+const markerItems: Ref<MarkerItem[]> = ref([]);
+
+const mapCenter = computed(() => {
+  if (!spot.value?.latitude || !spot.value?.longitude) return null;
+  return { lat: spot.value.latitude, lng: spot.value.longitude };
+});
 
 const isFavorite = computed(() => {
   if (!authStore.user || !favUserId.value) return true;
@@ -149,11 +167,13 @@ const isFavorite = computed(() => {
 
 const fetchSpotData = async () => {
   try {
-    const res = await $api.get(`/api/v1/spots/${route.params.id}`);
-    spot.value = res.data.spot;
+    const res = await $api.get<SpotShowResponse>(
+      `/api/v1/spots/${route.params.id}`,
+    );
+    spot.value = res.data.spot || null;
     prefecture.value = res.data.prefecture?.attributes?.name || "";
     location.value = res.data.location?.attributes?.name || "";
-    favUserId.value = res.data.favuser;
+    favUserId.value = res.data.favuser ?? null;
     reviewCount.value = res.data.reviews_count || 0;
     rating.value = res.data.average_rating || 2.6;
 

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -71,6 +71,16 @@ interface ApiClient {
     body?: RequestBody,
     options?: ApiRequestOptions,
   ): Promise<ApiResponse<T>>;
+  put<T = any>(
+    url: string,
+    body?: RequestBody,
+    options?: ApiRequestOptions,
+  ): Promise<ApiResponse<T>>;
+  patch<T = any>(
+    url: string,
+    body?: RequestBody,
+    options?: ApiRequestOptions,
+  ): Promise<ApiResponse<T>>;
   delete<T = any>(
     url: string,
     options?: ApiRequestOptions,
@@ -118,6 +128,7 @@ declare module "nuxt/app" {
   interface NuxtApp {
     $api?: ApiClient;
     $imageOptimization?: ImageOptimizationService;
+    $googleMapsKey?: string;
     $my?: {
       pageTitle(routeName: string): string;
       format(date: string | Date): string;

--- a/front/pages/account.vue
+++ b/front/pages/account.vue
@@ -1,16 +1,17 @@
 <template>
   <v-container>
-    <nuxt-child />
+    <NuxtPage />
   </v-container>
 </template>
 
-<script>
-export default {
+<script setup lang="ts">
+definePageMeta({
   layout: "loggedIn",
-  middleware({ route, redirect }) {
-    if (route.name === "account") {
-      return redirect("/");
-    }
-  },
-};
+  middleware: "auth",
+});
+
+const route = useRoute();
+if (route.name === "account") {
+  await navigateTo("/");
+}
 </script>

--- a/front/pages/account/settings.vue
+++ b/front/pages/account/settings.vue
@@ -1,58 +1,61 @@
 <template>
   <v-card class="mt-10">
-    <v-toolbar flat color="green lighten-4">
+    <v-toolbar flat color="green-lighten-4">
       <v-avatar size="120">
-        <v-img :src="photo" />
+        <v-img :src="photo || undefined" />
       </v-avatar>
       <v-toolbar-title class="ml-4">
-        {{ $auth.user.name }}さん
+        {{ authStore.user?.name }}さん
       </v-toolbar-title>
-      <nuxt-link to="userEdit" class="text-decoration-none">
+      <NuxtLink to="userEdit" class="text-decoration-none">
         <v-btn class="ml-5" rounded>
           <v-icon>mdi-pencil</v-icon>
           プロフィール編集
         </v-btn>
-      </nuxt-link>
+      </NuxtLink>
     </v-toolbar>
 
-    <v-tabs>
-      <v-tab>
-        <v-icon left> mdi-account </v-icon>
+    <v-tabs v-model="tab">
+      <v-tab value="reviews">
+        <v-icon start>mdi-account</v-icon>
         投稿したレビュー({{ myReview.length }})
       </v-tab>
-      <v-tab>
-        <v-icon left> mdi-heart </v-icon>
+      <v-tab value="liked">
+        <v-icon start>mdi-heart</v-icon>
         いいねしたレビュー({{ reviews.length }})
       </v-tab>
-      <v-tab>
-        <v-icon left> mdi-access-point </v-icon>
+      <v-tab value="favorites">
+        <v-icon start>mdi-access-point</v-icon>
         お気に入りスポット({{ likeSpot.length }})
       </v-tab>
-      <v-tab>
-        <v-icon left> mdi-account-multiple </v-icon>
+      <v-tab value="followings">
+        <v-icon start>mdi-account-multiple</v-icon>
         フォロー ({{ followUser.length }})
       </v-tab>
-      <v-tab>
-        <v-icon left> mdi-account-multiple </v-icon>
+      <v-tab value="followers">
+        <v-icon start>mdi-account-multiple</v-icon>
         フォロワー ({{ follower.length }})
       </v-tab>
-      <v-tab-item>
+    </v-tabs>
+
+    <v-tabs-window v-model="tab">
+      <v-tabs-window-item value="reviews">
         <v-row class="mx-2">
           <v-col v-for="s in myReview" :key="s.id" cols="12" md="4" sm="6">
             <v-card>
-              <v-img :src="s.image.url" :aspect-ratio="12 / 9" />
-              <nuxt-link
-                :to="`/spots/${s.spot.id}`"
+              <v-img :src="s.image?.url" :aspect-ratio="12 / 9" />
+              <NuxtLink
+                :to="`/spots/${s.spot?.id}`"
                 class="text-decoration-none"
               >
                 <v-card-title class="pb-0">
-                  {{ s.spot.name }}
+                  {{ s.spot?.name }}
                 </v-card-title>
-              </nuxt-link>
+              </NuxtLink>
               <v-card-text class="pb-1">
                 <v-row>
                   <v-rating v-model="s.rating" readonly />
-                  <span class="grey--text body-1 mr-2 pt-2">
+                  <span class="text-grey text-body-1 mr-2 pt-2">
                     ({{ s.rating }})
                   </span>
                 </v-row>
@@ -64,41 +67,42 @@
             </v-card>
           </v-col>
         </v-row>
-      </v-tab-item>
-      <v-tab-item>
+      </v-tabs-window-item>
+
+      <v-tabs-window-item value="liked">
         <v-row>
           <v-col v-for="i in reviews" :key="i.id" cols="12" md="4" sm="6">
             <v-card>
               <v-card-text>
                 <v-row>
                   <v-col cols="2" class="py-0">
-                    <nuxt-link
-                      :to="`/user/${i.user.id}`"
+                    <NuxtLink
+                      :to="`/user/${i.user?.id}`"
                       class="text-decoration-none"
                     >
                       <v-avatar size="36">
-                        <v-img :src="i.user.image.url" />
+                        <v-img :src="i.user?.image?.url" />
                       </v-avatar>
-                    </nuxt-link>
+                    </NuxtLink>
                   </v-col>
                   <v-col>
-                    <div>{{ i.user.name }}さんの投稿</div>
+                    <div>{{ i.user?.name }}さんの投稿</div>
                   </v-col>
                 </v-row>
               </v-card-text>
-              <v-img :src="i.image.url" :aspect-ratio="12 / 9" />
-              <nuxt-link
-                :to="`/spots/${i.spot.id}`"
+              <v-img :src="i.image?.url" :aspect-ratio="12 / 9" />
+              <NuxtLink
+                :to="`/spots/${i.spot?.id}`"
                 class="text-decoration-none"
               >
                 <v-card-title class="pb-0">
-                  {{ i.spot.name }}
+                  {{ i.spot?.name }}
                 </v-card-title>
-              </nuxt-link>
+              </NuxtLink>
               <v-card-text class="pb-1">
                 <v-row>
                   <v-rating v-model="i.rating" readonly />
-                  <span class="grey--text body-1 mr-2 pt-2">
+                  <span class="text-grey text-body-1 mr-2 pt-2">
                     ({{ i.rating }})
                   </span>
                 </v-row>
@@ -108,89 +112,140 @@
             </v-card>
           </v-col>
         </v-row>
-      </v-tab-item>
-      <v-tab-item>
+      </v-tabs-window-item>
+
+      <v-tabs-window-item value="favorites">
         <v-card flat>
           <v-card-text v-for="a in likeSpot" :key="a.id">
             <v-img
-              :src="a.photo.url"
+              :src="a.photo?.url"
               :aspect-ratio="16 / 9"
               max-height="200"
               max-width="250"
             />
-            <nuxt-link :to="`/spots/${a.id}`" class="text-decoration-none">
+            <NuxtLink :to="`/spots/${a.id}`" class="text-decoration-none">
               <v-card-title>{{ a.name }}</v-card-title>
-            </nuxt-link>
+            </NuxtLink>
           </v-card-text>
         </v-card>
-      </v-tab-item>
-      <v-tab-item>
+      </v-tabs-window-item>
+
+      <v-tabs-window-item value="followings">
         <v-card flat>
           <v-card-text v-for="v in followUser" :key="v.id">
             <v-avatar size="100">
-              <v-img :src="v.image.url" />
+              <v-img :src="v.image?.url" />
             </v-avatar>
-            <nuxt-link :to="`/user/${v.id}`" class="text-decoration-none">
+            <NuxtLink :to="`/user/${v.id}`" class="text-decoration-none">
               <v-card-title>{{ v.name }}</v-card-title>
-            </nuxt-link>
+            </NuxtLink>
             <follow-btn :user-id="v.id" :initial-is-following="true" />
           </v-card-text>
         </v-card>
-      </v-tab-item>
-      <v-tab-item>
+      </v-tabs-window-item>
+
+      <v-tabs-window-item value="followers">
         <v-card flat>
           <v-card-text v-for="t in follower" :key="t.id">
             <v-avatar size="100">
-              <v-img :src="t.image.url" />
+              <v-img :src="t.image?.url" />
             </v-avatar>
-            <nuxt-link :to="`/user/${t.id}`" class="text-decoration-none">
+            <NuxtLink :to="`/user/${t.id}`" class="text-decoration-none">
               <v-card-title>{{ t.name }}</v-card-title>
-            </nuxt-link>
+            </NuxtLink>
             <follow-btn
               :user-id="t.id"
               :initial-is-following="isFollowingUser(t.id)"
             />
           </v-card-text>
         </v-card>
-      </v-tab-item>
-    </v-tabs>
+      </v-tabs-window-item>
+    </v-tabs-window>
   </v-card>
 </template>
 
-<script>
-export default {
-  data() {
-    return {
-      tab: null,
-      reviews: [],
-      myReview: [],
-      likeSpot: [],
-      followUser: [],
-      follower: [],
-      user: null,
-      photo: null,
-    };
-  },
-  mounted() {
-    this.$axios
-      .get(`/api/v1/users/user_data`)
-      .then((res) => {
-        this.user = res.data.user;
-        this.photo = res.data.user.image.url;
-        this.reviews = res.data.liked_reviews || [];
-        this.myReview = res.data.reviews || [];
-        this.likeSpot = res.data.favorites || [];
-        this.followUser = res.data.followings || [];
-        this.follower = res.data.followers || [];
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  },
-  methods: {
-    isFollowingUser(userId) {
-      return this.followUser.some((user) => user.id === userId);
-    },
-  },
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useAuthStore } from "~/stores/auth";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
+
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+interface ImageUrl {
+  url?: string;
+}
+
+interface SpotSummary {
+  id: number;
+  name: string;
+}
+
+interface UserSummary {
+  id: number;
+  name: string;
+  image?: ImageUrl;
+}
+
+interface ReviewItem {
+  id: number;
+  title: string;
+  text: string;
+  rating: number;
+  image?: ImageUrl;
+  spot?: SpotSummary;
+  user?: UserSummary;
+}
+
+interface FavoriteSpot {
+  id: number;
+  name: string;
+  photo?: ImageUrl;
+}
+
+interface UserDataResponse {
+  user?: UserSummary & { image?: ImageUrl };
+  reviews?: ReviewItem[];
+  liked_reviews?: ReviewItem[];
+  favorites?: FavoriteSpot[];
+  followings?: UserSummary[];
+  followers?: UserSummary[];
+}
+
+const authStore = useAuthStore();
+const $api = useApi();
+const toastStore = useToastStore();
+
+const tab = ref("reviews");
+const reviews = ref<ReviewItem[]>([]);
+const myReview = ref<ReviewItem[]>([]);
+const likeSpot = ref<FavoriteSpot[]>([]);
+const followUser = ref<UserSummary[]>([]);
+const follower = ref<UserSummary[]>([]);
+const photo = ref<string | null>(null);
+
+const isFollowingUser = (userId: number) => {
+  return followUser.value.some((user) => user.id === userId);
 };
+
+onMounted(async () => {
+  try {
+    const res = await $api.get<UserDataResponse>("/api/v1/users/user_data");
+    photo.value = res.data.user?.image?.url || null;
+    reviews.value = res.data.liked_reviews || [];
+    myReview.value = res.data.reviews || [];
+    likeSpot.value = res.data.favorites || [];
+    followUser.value = res.data.followings || [];
+    follower.value = res.data.followers || [];
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "ユーザーデータの取得に失敗しました",
+      color: "error",
+    });
+  }
+});
 </script>

--- a/front/pages/account/userEdit.vue
+++ b/front/pages/account/userEdit.vue
@@ -11,72 +11,121 @@
       </v-row>
       <v-row>
         <v-col cols="6">
-          <v-img :src="preview" />
+          <v-img :src="preview || undefined" />
           <v-file-input
-            v-model="user.image"
             chips
             small-chips
             show-size
             label="画像(任意)"
             accept="image/png, image/jpeg, image/bmp"
             prepend-icon="mdi-camera"
-            @change="setImage"
+            @update:model-value="setImage"
           />
         </v-col>
       </v-row>
       <v-row>
         <v-col cols="3">
-          <v-btn color="primary" @click="editSpot"> 登録する </v-btn>
+          <v-btn color="primary" :loading="loading" @click="editUser">
+            登録する
+          </v-btn>
         </v-col>
       </v-row>
     </v-form>
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      user: "",
-      preview: null,
+<script setup lang="ts">
+import { reactive, ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "~/stores/auth";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
+
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+interface UserForm {
+  name: string;
+  introduction: string;
+}
+
+interface UserShowResponse {
+  user?: {
+    name?: string;
+    introduction?: string;
+    image?: {
+      url?: string;
     };
-  },
-  mounted() {
-    this.$axios
-      .get(`/api/v1/users/${this.$auth.user.id}`)
-      .then((res) => {
-        this.user = res.data;
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  },
-  methods: {
-    setImage(e) {
-      this.image = e;
-      this.preview = URL.createObjectURL(e);
-    },
-    editSpot() {
-      const formData = new FormData();
-      formData.append("name", this.user.name);
-      formData.append("introduction", this.user.introduction);
-      formData.append("image", this.user.image);
-      const config = {
-        headers: {
-          "content-type": "multipart/form-data",
-        },
-      };
-      this.$axios
-        .put(`/api/v1/users/${this.$auth.user.id}`, formData, config)
-        .then((res) => {
-          if (res.data) {
-            this.$router.push("/");
-          }
-        });
-    },
-  },
+  };
+}
+
+const authStore = useAuthStore();
+const $api = useApi();
+const router = useRouter();
+const toastStore = useToastStore();
+
+const user = reactive<UserForm>({
+  name: "",
+  introduction: "",
+});
+const image = ref<File | null>(null);
+const preview = ref<string | null>(null);
+const loading = ref(false);
+
+const setImage = (value: File | File[] | null) => {
+  const file = Array.isArray(value) ? value[0] : value;
+  if (!file) {
+    image.value = null;
+    preview.value = null;
+    return;
+  }
+  image.value = file;
+  preview.value = URL.createObjectURL(file);
 };
+
+const editUser = async () => {
+  if (!authStore.user?.id) return;
+
+  loading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append("name", user.name);
+    formData.append("introduction", user.introduction);
+    if (image.value) {
+      formData.append("image", image.value);
+    }
+
+    await $api.put(`/api/v1/users/${authStore.user.id}`, formData);
+    router.push("/");
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "プロフィールの更新に失敗しました",
+      color: "error",
+    });
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(async () => {
+  if (!authStore.user?.id) return;
+
+  try {
+    const res = await $api.get<UserShowResponse>(
+      `/api/v1/users/${authStore.user.id}`,
+    );
+    user.name = res.data.user?.name || "";
+    user.introduction = res.data.user?.introduction || "";
+    preview.value = res.data.user?.image?.url || null;
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "ユーザー情報の取得に失敗しました",
+      color: "error",
+    });
+  }
+});
 </script>

--- a/front/pages/favorites.vue
+++ b/front/pages/favorites.vue
@@ -4,7 +4,7 @@
     <v-row>
       <v-col v-for="(favorite, index) in fspots" :key="index" cols="6">
         <v-card :to="`/spots/${favorite.id}`">
-          <v-img :src="favorite.photo.url" />
+          <v-img :src="favorite.photo?.url" />
           <v-card-title>{{ favorite.name }}</v-card-title>
         </v-card>
       </v-col>
@@ -12,22 +12,42 @@
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      fspots: [],
-    };
-  },
-  mounted() {
-    this.$axios.get("/api/v1/users/user_data").then((res) => {
-      if (res.data) {
-        this.fspots = res.data.favorites || [];
-      }
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
+
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+interface FavoriteSpot {
+  id: number;
+  name: string;
+  photo?: {
+    url: string;
+  };
+}
+
+interface UserDataResponse {
+  favorites?: FavoriteSpot[];
+}
+
+const $api = useApi();
+const toastStore = useToastStore();
+const fspots = ref<FavoriteSpot[]>([]);
+
+onMounted(async () => {
+  try {
+    const res = await $api.get<UserDataResponse>("/api/v1/users/user_data");
+    fspots.value = res.data.favorites || [];
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "お気に入りの取得に失敗しました",
+      color: "error",
     });
-  },
-};
+  }
+});
 </script>

--- a/front/pages/location/_id.vue
+++ b/front/pages/location/_id.vue
@@ -1,54 +1,91 @@
 <template>
   <v-container>
     <breadcrumbs />
-    {{ spot.name }}のスポット一覧
+    {{ spotName }}のスポット一覧
 
     <v-row>
       <v-col v-for="jspot in jspots" :key="jspot.id" cols="12" sm="4">
         <v-card>
-          <nuxt-link
-            :to="$my.spotLinkTo(jspot.id)"
-            class="text-decoration-none"
-          >
-            <v-img :src="jspot.photo.url" :aspect-ratio="16 / 9" />
-            <!-- <v-card-text>{{ jspot }}</v-card-text> -->
+          <NuxtLink :to="spotLinkTo(jspot.id)" class="text-decoration-none">
+            <v-img :src="jspot.photo?.url" :aspect-ratio="16 / 9" />
             <v-card-title>{{ jspot.name }}</v-card-title>
             <v-card-text>{{ jspot.introduction }}</v-card-text>
-            <v-card-text>{{ prefecture.attributes }}</v-card-text>
-            <!-- <v-card-text v-text="jspot.introduction"/> -->
-          </nuxt-link>
+          </NuxtLink>
         </v-card>
-      </v-col>
-      <v-col v-for="(p, index) in prefecture" :key="index">
-        <div>{{ p.name }}</div>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      spot: {},
-      jspots: [],
-      prefecture: [],
-    };
-  },
-  mounted() {
-    this.$axios
-      .get(`/api/v1/locations/${this.$route.params.id}`)
-      .then((res) => {
-        this.spot = res.data.location.attributes;
-        this.jspots = res.data.spot;
-        this.prefecture = res.data.prefecture;
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  },
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRoute } from "vue-router";
+import { setPageLayout } from "#imports";
+import { useAuth } from "~/composables/useAuth";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
+
+definePageMeta({
+  layout: "welcome",
+});
+
+interface SpotItem {
+  id: number;
+  name: string;
+  introduction?: string;
+  photo?: {
+    url?: string;
+  };
+}
+
+interface ActiveHashResource {
+  id?: number;
+  name?: string;
+  attributes?: {
+    id?: number;
+    name?: string;
+  };
+}
+
+interface LocationShowResponse {
+  location?: ActiveHashResource;
+  spot?: SpotItem[];
+}
+
+const route = useRoute();
+const { loggedIn } = useAuth();
+const $api = useApi();
+const toastStore = useToastStore();
+const { $my } = useNuxtApp();
+
+const spotName = ref("");
+const jspots = ref<SpotItem[]>([]);
+
+const spotLinkTo = (id: number) => {
+  return $my?.spotLinkTo(id) ?? `/spots/${id}`;
 };
+
+const resolveName = (resource?: ActiveHashResource) => {
+  return resource?.attributes?.name || resource?.name || "";
+};
+
+onMounted(async () => {
+  if (loggedIn.value) {
+    setPageLayout("loggedIn");
+  }
+
+  try {
+    const res = await $api.get<LocationShowResponse>(
+      `/api/v1/locations/${route.params.id}`,
+    );
+    spotName.value = resolveName(res.data.location);
+    jspots.value = res.data.spot || [];
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "スポット一覧の取得に失敗しました",
+      color: "error",
+    });
+  }
+});
 </script>

--- a/front/pages/logout.vue
+++ b/front/pages/logout.vue
@@ -1,12 +1,21 @@
 <template>
   <div />
 </template>
-<script>
-export default {
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useAuth } from "~/composables/useAuth";
+
+definePageMeta({
   layout: "logout",
-  async beforeCreate() {
-    await this.$auth.logout();
-    this.$router.replace("/");
-  },
-};
+});
+
+const { logout } = useAuth();
+const router = useRouter();
+
+onMounted(async () => {
+  await logout();
+  router.replace("/");
+});
 </script>

--- a/front/pages/newspots.vue
+++ b/front/pages/newspots.vue
@@ -3,28 +3,22 @@
     <v-row justify="center">
       <v-col cols="12" sm="6" class="my-6 text-center" align-self="center">
         <h1 class="mb-4">スポット投稿</h1>
-        <div class="red--text">
+        <div class="text-error">
           {{ alert }}
         </div>
         <v-text-field
           v-model="name"
           label="スポット名(必須)"
-          prepend-icon=""
           type="text"
-          outlined
+          variant="outlined"
           @change="onChange"
         />
-
-        <!-- <div>緯度{{ lat }}</div>
-        <div>{{ locations }}</div>
-        <div>{{ address }}</div> -->
 
         <v-text-field
           v-model="introduction"
           label="説明(必須)"
-          prepend-icon=""
           type="text"
-          outlined
+          variant="outlined"
         />
         <v-img :src="preview" />
         <v-file-input
@@ -34,143 +28,235 @@
           label="画像(任意)"
           accept="image/png, image/jpeg, image/bmp"
           prepend-icon="mdi-camera"
-          @change="setImage"
+          @update:model-value="setImage"
         />
         <v-select
-          v-model="prefectures"
+          v-model="selectedPrefectureId"
           label="都道府県(必須)"
-          item-text="attributes.name"
-          item-value="attributes.id"
-          :items="prefecture"
-          outlined
+          item-title="name"
+          item-value="id"
+          :items="prefectureOptions"
+          variant="outlined"
         />
 
         <v-text-field
           v-model="address"
           label="住所(必須)"
-          prepend-icon=""
           type="text"
-          outlined
+          variant="outlined"
         />
 
         <v-select
-          v-model="locations"
+          v-model="selectedLocationId"
           label="ジャンル(必須)"
-          item-text="attributes.name"
-          item-value="attributes.id"
-          :items="location"
-          outlined
+          item-title="name"
+          item-value="id"
+          :items="locationOptions"
+          variant="outlined"
         />
-        <v-btn color="primary" @click="createSpot"> スポットを投稿する </v-btn>
+        <v-btn color="primary" :loading="loading" @click="createSpot">
+          スポットを投稿する
+        </v-btn>
       </v-col>
-      <!-- <v-col cols="12" sm="6">
-        <v-card class="mx-auto" tile>
-          <v-list rounded>
-            <v-subheader>SPOTS</v-subheader>
-            <v-list-item-group color="primary">
-              <v-list-item v-for="spot in spots" :key="spots.id" @click="">
-                <v-list-item-content>
-                  <nuxt-link
-                    :to="$my.spotLinkTo(spot.id)"
-                    class="text-decoration-none"
-                  >
-                    <v-list-item-title v-text="spot.id" />
-                    <v-list-item-title v-text="spot.name" />
-                  </nuxt-link>
-                </v-list-item-content>
-              </v-list-item>
-            </v-list-item-group>
-          </v-list>
-        </v-card>
-      </v-col> -->
     </v-row>
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      name: "",
-      introduction: "",
-      prefectures: "",
-      address: "",
-      locations: "",
-      lat: "",
-      lng: "",
-      alert: "",
-      image: null,
-      preview: "",
-      geocoder: {},
-      spots: [],
-      prefecture: [],
-      location: [],
-    };
-  },
-  mounted() {
-    this.$axios.get("/api/v1/spots").then((res) => {
-      if (res.data) {
-        this.spots = res.data.spots;
-        this.prefecture = res.data.prefecture;
-        this.location = res.data.location;
-      }
-    }),
-      this.$gmapApiPromiseLazy().then(() => {
-        this.geocoder = new google.maps.Geocoder();
-      });
-  },
-  methods: {
-    // 入力されたスポット名を住所変換
-    onChange() {
-      this.geocoder.geocode(
-        {
-          address: this.name,
-        },
-        (results, status) => {
-          if (status === google.maps.GeocoderStatus.OK) {
-            this.alert = "";
-            this.lat = results[0].geometry.location.lat();
-            this.lng = results[0].geometry.location.lng();
-            const ad = results[0].formatted_address.replace("日本、", "");
-            this.address = ad;
-          } else {
-            this.alert = "正しいスポットを入力してください";
-          }
-        },
-      );
-    },
-    setImage(e) {
-      this.image = e;
-      this.preview = URL.createObjectURL(e);
-    },
-    // スポットをaxiosで登録
-    createSpot(_e) {
-      const formData = new FormData();
-      formData.append("photo", this.image);
-      formData.append("name", this.name);
-      formData.append("introduction", this.introduction);
-      formData.append("prefecture_id", this.prefectures);
-      formData.append("latitude", this.lat);
-      formData.append("longitude", this.lng);
-      formData.append("address", this.address);
-      formData.append("location_id", this.locations);
-      const config = {
-        headers: {
-          "content-type": "multipart/form-data",
-        },
-      };
-      this.$axios.post("/api/v1/spots", formData, config).then((res) => {
-        if (res.data) {
-          this.spots.push(res.data);
-          this.$router.push("/");
-        }
-      });
-    },
-  },
-};
-</script>
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
 
-<style></style>
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+interface ActiveHashItem {
+  id: number;
+  name: string;
+}
+
+interface SpotsIndexResponse {
+  spots?: unknown[];
+  prefectures?: ActiveHashItem[];
+  locations?: ActiveHashItem[];
+}
+
+interface GeocoderResult {
+  formatted_address: string;
+  geometry: {
+    location: {
+      lat: () => number;
+      lng: () => number;
+    };
+  };
+}
+
+interface GeocoderLike {
+  geocode: (
+    request: { address: string },
+    callback: (results: GeocoderResult[] | null, status: string) => void,
+  ) => void;
+}
+
+interface GoogleMapsWindow {
+  google?: {
+    maps?: {
+      Geocoder: new () => GeocoderLike;
+      GeocoderStatus?: { OK: string };
+    };
+  };
+}
+
+const $api = useApi();
+const router = useRouter();
+const toastStore = useToastStore();
+const { $googleMapsKey } = useNuxtApp();
+
+const name = ref("");
+const introduction = ref("");
+const selectedPrefectureId = ref<number | null>(null);
+const address = ref("");
+const selectedLocationId = ref<number | null>(null);
+const lat = ref<number | null>(null);
+const lng = ref<number | null>(null);
+const alert = ref("");
+const image = ref<File | null>(null);
+const preview = ref("");
+const loading = ref(false);
+const prefectureOptions = ref<ActiveHashItem[]>([]);
+const locationOptions = ref<ActiveHashItem[]>([]);
+const geocoder = ref<GeocoderLike | null>(null);
+
+const getGoogleMaps = () => {
+  return (window as unknown as GoogleMapsWindow).google?.maps;
+};
+
+const loadGoogleMapsScript = (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    if (getGoogleMaps()?.Geocoder) {
+      resolve();
+      return;
+    }
+
+    const existing = document.querySelector<HTMLScriptElement>(
+      'script[data-google-maps="true"]',
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve());
+      existing.addEventListener("error", () =>
+        reject(new Error("Google Maps script failed to load")),
+      );
+      return;
+    }
+
+    const apiKey = typeof $googleMapsKey === "string" ? $googleMapsKey : "";
+    if (!apiKey) {
+      reject(new Error("Google Maps API key is not configured"));
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}`;
+    script.async = true;
+    script.defer = true;
+    script.dataset.googleMaps = "true";
+    script.onload = () => resolve();
+    script.onerror = () =>
+      reject(new Error("Google Maps script failed to load"));
+    document.head.appendChild(script);
+  });
+};
+
+const onChange = () => {
+  if (!geocoder.value || !name.value) return;
+
+  geocoder.value.geocode(
+    { address: name.value },
+    (results: GeocoderResult[] | null, status: string) => {
+      const okStatus = getGoogleMaps()?.GeocoderStatus?.OK ?? "OK";
+      if (status === okStatus && results?.[0]) {
+        alert.value = "";
+        lat.value = results[0].geometry.location.lat();
+        lng.value = results[0].geometry.location.lng();
+        address.value = results[0].formatted_address.replace("日本、", "");
+      } else {
+        alert.value = "正しいスポットを入力してください";
+      }
+    },
+  );
+};
+
+const setImage = (value: File | File[] | null) => {
+  const file = Array.isArray(value) ? value[0] : value;
+  if (!file) {
+    image.value = null;
+    preview.value = "";
+    return;
+  }
+  image.value = file;
+  preview.value = URL.createObjectURL(file);
+};
+
+const createSpot = async () => {
+  loading.value = true;
+  try {
+    const formData = new FormData();
+    if (image.value) {
+      formData.append("photo", image.value);
+    }
+    formData.append("name", name.value);
+    formData.append("introduction", introduction.value);
+    if (selectedPrefectureId.value != null) {
+      formData.append("prefecture_id", String(selectedPrefectureId.value));
+    }
+    if (lat.value != null) {
+      formData.append("latitude", String(lat.value));
+    }
+    if (lng.value != null) {
+      formData.append("longitude", String(lng.value));
+    }
+    formData.append("address", address.value);
+    if (selectedLocationId.value != null) {
+      formData.append("location_id", String(selectedLocationId.value));
+    }
+
+    await $api.post("/api/v1/spots", formData);
+    router.push("/");
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "スポットの投稿に失敗しました",
+      color: "error",
+    });
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(async () => {
+  try {
+    const res = await $api.get<SpotsIndexResponse>("/api/v1/spots");
+    prefectureOptions.value = res.data.prefectures || [];
+    locationOptions.value = res.data.locations || [];
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "スポット情報の取得に失敗しました",
+      color: "error",
+    });
+  }
+
+  try {
+    await loadGoogleMapsScript();
+    const maps = getGoogleMaps();
+    if (maps?.Geocoder) {
+      geocoder.value = new maps.Geocoder();
+    }
+  } catch (error) {
+    console.error(error);
+  }
+});
+</script>

--- a/front/pages/prefecture/_id.vue
+++ b/front/pages/prefecture/_id.vue
@@ -1,45 +1,90 @@
 <template>
   <v-container>
     <breadcrumbs />
-    {{ spot.name }}のスポット一覧
+    {{ spotName }}のスポット一覧
     <v-row>
       <v-col v-for="(jspot, index) in pspots" :key="index" cols="12" sm="4">
         <v-card>
-          <nuxt-link
-            :to="$my.spotLinkTo(jspot.id)"
-            class="text-decoration-none"
-          >
-            <v-img :src="jspot.photo.url" :aspect-ratio="12 / 9" />
+          <NuxtLink :to="spotLinkTo(jspot.id)" class="text-decoration-none">
+            <v-img :src="jspot.photo?.url" :aspect-ratio="12 / 9" />
             <v-card-title>{{ jspot.name }}</v-card-title>
-            <v-card-text v-text="jspot.introduction" />
-          </nuxt-link>
+            <v-card-text>{{ jspot.introduction }}</v-card-text>
+          </NuxtLink>
         </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      spot: {},
-      pspots: [],
-    };
-  },
-  mounted() {
-    this.$axios
-      .get(`/api/v1/prefectures/${this.$route.params.id}`)
-      .then((res) => {
-        this.spot = res.data.prefecture.attributes;
-        this.pspots = res.data.spot;
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  },
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRoute } from "vue-router";
+import { setPageLayout } from "#imports";
+import { useAuth } from "~/composables/useAuth";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
+
+definePageMeta({
+  layout: "welcome",
+});
+
+interface SpotItem {
+  id: number;
+  name: string;
+  introduction?: string;
+  photo?: {
+    url?: string;
+  };
+}
+
+interface ActiveHashResource {
+  id?: number;
+  name?: string;
+  attributes?: {
+    id?: number;
+    name?: string;
+  };
+}
+
+interface PrefectureShowResponse {
+  prefecture?: ActiveHashResource;
+  spot?: SpotItem[];
+}
+
+const route = useRoute();
+const { loggedIn } = useAuth();
+const $api = useApi();
+const toastStore = useToastStore();
+const { $my } = useNuxtApp();
+
+const spotName = ref("");
+const pspots = ref<SpotItem[]>([]);
+
+const spotLinkTo = (id: number) => {
+  return $my?.spotLinkTo(id) ?? `/spots/${id}`;
 };
+
+const resolveName = (resource?: ActiveHashResource) => {
+  return resource?.attributes?.name || resource?.name || "";
+};
+
+onMounted(async () => {
+  if (loggedIn.value) {
+    setPageLayout("loggedIn");
+  }
+
+  try {
+    const res = await $api.get<PrefectureShowResponse>(
+      `/api/v1/prefectures/${route.params.id}`,
+    );
+    spotName.value = resolveName(res.data.prefecture);
+    pspots.value = res.data.spot || [];
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "スポット一覧の取得に失敗しました",
+      color: "error",
+    });
+  }
+});
 </script>

--- a/front/pages/spots/_id/reviews/new.vue
+++ b/front/pages/spots/_id/reviews/new.vue
@@ -7,9 +7,9 @@
         <v-divider class="mb-2" />
         <v-rating
           v-model="rating"
-          background-color="purple lighten-3"
+          bg-color="purple-lighten-3"
           color="purple"
-          large
+          size="large"
           hover
         />
         <h2>口コミ</h2>
@@ -18,35 +18,33 @@
         <v-text-field
           v-model="title"
           placeholder="感想や思い出に残ったことをまとめましょう"
-          outlined
+          variant="outlined"
         />
         <h4>内容(◯文字以内)</h4>
         <v-textarea
           v-model="text"
-          outlined
+          variant="outlined"
           placeholder="日本でも有名な温泉街で、日帰りで友人と車で出かけました。着いた時から硫黄の香りと湯けむりで、ワクワクしました。なにより温泉街はとても心地よく、浴衣でまち歩きをしながら食べたり、お店にも立ち寄ったりすることができます。温泉にもゆっくり浸かることができ、大満足でした。"
         />
         <h2>写真</h2>
         <v-divider class="mb-4" />
-        <!-- 画像プレビュー -->
         <v-img :src="preview" max-width="300" />
         <v-file-input
           accept="image/png, image/jpeg, image/bmp"
           show-size
           counter
           label="File input"
-          @change="setImage"
+          @update:model-value="setImage"
         />
         <h2>行った時期</h2>
         <v-divider class="mb-4" />
         <v-row justify="center">
-          <v-date-picker v-model="picker" type="month" locale="jp" />
+          <v-date-picker v-model="picker" type="month" locale="ja" />
         </v-row>
         <v-divider class="mb-2" />
         <v-row justify="center">
           <v-btn
             color="primary"
-            dark
             min-width="300"
             :disabled="!allInput"
             :loading="loading"
@@ -60,83 +58,101 @@
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-  data() {
-    return {
-      // picker: new Date().toISOString().substr(0, 10),
-      rating: null,
-      title: "",
-      text: "",
-      picker: "",
-      image: null,
-      preview: "",
-      spots: [],
-      reviews: [],
-      id: [],
-      loading: false,
-    };
-  },
-  computed: {
-    // すべてインプット後に投稿ボタンを押せるようにする
-    allInput() {
-      const requiredFields = ["title", "text", "picker", "rating"];
-      return !requiredFields.includes("");
-    },
-  },
-  created() {
-    this.$axios
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "~/stores/auth";
+import { useApi } from "~/composables/useApi";
+import { useToastStore } from "~/stores/toast";
 
-      .get(`/api/v1/spots/${this.$route.params.id}`)
-      .then((res) => {
-        // const spot = res.data
-        this.spots = res.data;
-        this.id = res.data.id;
-        // this.review = res.data.review
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  },
-  methods: {
-    setImage(e) {
-      this.image = e;
-      this.preview = URL.createObjectURL(e);
-    },
-    createReview() {
-      this.loading = true;
-      const formData = new FormData();
-      formData.append("title", this.title);
-      formData.append("text", this.text);
-      formData.append("image", this.image);
-      formData.append("wentday", this.picker);
-      formData.append("rating", this.rating);
-      formData.append("spot_id", this.id);
-      formData.append("user_id", this.$auth.user.id);
-      const config = {
-        headers: {
-          "content-type": "multipart/form-data",
-        },
-      };
-      this.$axios
-        .post(
-          `/api/v1/spots/${this.$route.params.id}/reviews/`,
-          formData,
-          config,
-        )
-        .then((res) => {
-          this.$router.push("/");
-          if (res.data) {
-            this.reviews.push(res.data);
-          }
-        })
-        .catch((error) => console.log(error));
-    },
-  },
+definePageMeta({
+  layout: "loggedIn",
+  middleware: "auth",
+});
+
+interface SpotShowResponse {
+  spot?: {
+    id: number;
+  };
+  id?: number;
+}
+
+const route = useRoute();
+const router = useRouter();
+const authStore = useAuthStore();
+const $api = useApi();
+const toastStore = useToastStore();
+
+const rating = ref<number | undefined>(undefined);
+const title = ref("");
+const text = ref("");
+const picker = ref("");
+const image = ref<File | null>(null);
+const preview = ref("");
+const spotId = ref<number | null>(null);
+const loading = ref(false);
+
+const allInput = computed(() => {
+  return Boolean(
+    title.value && text.value && picker.value && rating.value !== undefined,
+  );
+});
+
+const setImage = (value: File | File[] | null) => {
+  const file = Array.isArray(value) ? value[0] : value;
+  if (!file) {
+    image.value = null;
+    preview.value = "";
+    return;
+  }
+  image.value = file;
+  preview.value = URL.createObjectURL(file);
 };
+
+const createReview = async () => {
+  if (!authStore.user?.id || spotId.value == null || rating.value === undefined)
+    return;
+
+  loading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append("title", title.value);
+    formData.append("text", text.value);
+    if (image.value) {
+      formData.append("image", image.value);
+    }
+    formData.append("wentday", picker.value);
+    formData.append("rating", String(rating.value));
+    formData.append("spot_id", String(spotId.value));
+    formData.append("user_id", String(authStore.user.id));
+
+    await $api.post(`/api/v1/spots/${route.params.id}/reviews/`, formData);
+    router.push("/");
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "口コミの投稿に失敗しました",
+      color: "error",
+    });
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(async () => {
+  try {
+    const res = await $api.get<SpotShowResponse>(
+      `/api/v1/spots/${route.params.id}`,
+    );
+    spotId.value = res.data.spot?.id ?? res.data.id ?? null;
+  } catch (error) {
+    console.error(error);
+    toastStore.showToast({
+      message: "スポット情報の取得に失敗しました",
+      color: "error",
+    });
+  }
+});
 </script>
 
 <style>

--- a/front/pages/user/_id.vue
+++ b/front/pages/user/_id.vue
@@ -19,10 +19,20 @@
   </v-container>
 </template>
 
-<script>
-export default {
-  layout({ $auth }) {
-    return $auth.loggedIn ? "loggedIn" : "welcome";
-  },
-};
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { setPageLayout } from "#imports";
+import { useAuth } from "~/composables/useAuth";
+
+definePageMeta({
+  layout: "welcome",
+});
+
+const { loggedIn } = useAuth();
+
+onMounted(() => {
+  if (loggedIn.value) {
+    setPageLayout("loggedIn");
+  }
+});
 </script>

--- a/front/plugins/api.ts
+++ b/front/plugins/api.ts
@@ -6,12 +6,23 @@ type ApiRequestOptions = Omit<RequestInit, "body" | "method"> & {
   params?: Record<string, unknown>;
 };
 type RequestBody = Record<string, unknown> | FormData | null;
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 type ApiClient = {
   get<T = any>(
     url: string,
     options?: ApiRequestOptions,
   ): Promise<ApiResponse<T>>;
   post<T = any>(
+    url: string,
+    body?: RequestBody,
+    options?: ApiRequestOptions,
+  ): Promise<ApiResponse<T>>;
+  put<T = any>(
+    url: string,
+    body?: RequestBody,
+    options?: ApiRequestOptions,
+  ): Promise<ApiResponse<T>>;
+  patch<T = any>(
     url: string,
     body?: RequestBody,
     options?: ApiRequestOptions,
@@ -27,27 +38,30 @@ export default defineNuxtPlugin(() => {
   const isDev = process.env.NODE_ENV !== "production";
   const authStore = useAuthStore();
 
-  // Nuxt 3ではaxiosではなく組み込みのfetchを使用
   const apiFetch = $fetch.create({
     baseURL: config.public.apiBaseUrl,
     headers: {
       "Content-Type": "application/json",
     },
     onRequest({ options }: FetchContext<unknown>) {
-      // リクエストにトークンを添付
+      const headers = new Headers(options.headers as HeadersInit | undefined);
+
       if (authStore.token) {
-        const headers = new Headers(options.headers as HeadersInit | undefined);
         headers.set("Authorization", `Bearer ${authStore.token}`);
-        options.headers = headers;
       }
 
-      // リクエストログ
+      // FormData のときはブラウザに Content-Type (boundary付き) を任せる
+      if (options.body instanceof FormData) {
+        headers.delete("Content-Type");
+      }
+
+      options.headers = headers;
+
       if (isDev) {
         console.log("API Request:", options);
       }
     },
     onResponse({ response }: { response: FetchResponse<unknown> }) {
-      // レスポンスログ
       if (isDev) {
         console.log("API Response:", response);
       }
@@ -57,7 +71,6 @@ export default defineNuxtPlugin(() => {
     }: {
       response: FetchResponse<unknown> | undefined;
     }) {
-      // エラーログ
       console.error("API Error:", response?.status, response?._data);
     },
   });
@@ -65,7 +78,7 @@ export default defineNuxtPlugin(() => {
   const request = async <T = any>(
     url: string,
     options: ApiRequestOptions & {
-      method: "GET" | "POST" | "DELETE";
+      method: HttpMethod;
       body?: RequestBody;
     },
   ): Promise<ApiResponse<T>> => {
@@ -77,6 +90,10 @@ export default defineNuxtPlugin(() => {
     get: (url, options) => request(url, { ...options, method: "GET" }),
     post: (url, body, options) =>
       request(url, { ...options, method: "POST", body }),
+    put: (url, body, options) =>
+      request(url, { ...options, method: "PUT", body }),
+    patch: (url, body, options) =>
+      request(url, { ...options, method: "PATCH", body }),
     delete: (url, options) => request(url, { ...options, method: "DELETE" }),
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

[REFACTORING_PLAN.md](https://github.com/Ryo-cool/Nature-Spots/blob/master/REFACTORING_PLAN.md) の **Phase 1 Critical** を実装しました。

Backend の機能障害・認可穴と、Frontend の `$axios`/`$auth` レガシー依存をまとめて解消しています。

## Backend

- `RelationshipsController`: 未定義の `active_relationships` → `relationships`
- `UserPolicy` 追加、`Users#update` / `#show` に `authorize`
- `Users#create` 実装（signup と整合、`activated: true`）
- `LocationsController` / `PrefecturesController` の show バグ修正、ActiveHash の 404 対応
- `schema.rb` に `spot_seasons` を反映
- `Authorization::NotAuthorizedError` を ApplicationController で rescue（403）
- request spec 追加: users / relationships / locations / prefectures

## Frontend

- `$axios` / `$auth` 依存ページを Composition API + `$api` / `useAuth` へ移行
  - logout, favorites, newspots, settings, userEdit, reviews/new, location, prefecture, user
- `plugins/api.ts` に `put` / `patch`、FormData 時の Content-Type 削除
- `spotData.vue` の地図を `vue3-google-map` に統一
- reviews/new の必須バリデーションバグ修正

## 検証

- `bundle exec rspec spec/requests/api/v1/` → **46 examples, 0 failures**
- `yarn type-check` / `yarn lint` → 成功

## 残課題（次フェーズ）

- Phase 2: API レスポンス形式統一、認証フロー一本化、Policy 拡大
- `account/password.vue` は空のまま（対象外）
- welcome 系 Options API は Phase 3 で対応

関連: #98（計画書）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283914-8ea7-402d-a57d-3744cabfbe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283914-8ea7-402d-a57d-3744cabfbe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

